### PR TITLE
fix map ID string replacement when compiling collection tags for maps

### DIFF
--- a/src/pages/maps/[identifier].astro
+++ b/src/pages/maps/[identifier].astro
@@ -24,8 +24,7 @@ facetEntries.forEach((facet) => {
   if (facet.data['facet-categories']) {
     facet.data['facet-categories'].forEach((categoryEntry) => {
       categoryEntry['entries'].forEach((entry) => {
-        const rewrittenId = data.dcMetadata.id.replaceAll(':', '--');
-        if (entry === rewrittenId) {
+        if (entry === data.dcMetadata.id) {
           data.dcMetadata.facetCategories.push({
             id: categoryEntry.id,
             title: categoryEntry.title,


### PR DESCRIPTION
This removes the string replacement performed when checking the ID of map collection tags since updating the ID format in 342ead99df8c82810f4cfe0efec140fca513e169