### PR TITLE
Feature/collection card floats

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,6 @@
 	@apply inline-block py-1 px-2 bg-bismark-500 text-white no-underline rounded transition-colors duration-300 ease-in-out hover:bg-bismark-700;
 }
 
-.markdown .card {
+.markdown > astro-island > .card {
 	@apply max-w-sm mb-4;
 }

--- a/src/components/CollectionCard.astro
+++ b/src/components/CollectionCard.astro
@@ -3,10 +3,11 @@ import { getEntry } from "astro:content";
 import LazyCard from '@components/LazyCard.vue';
 
 interface Props {
+  className: string;
   identifier: string;
 }
 
-const { identifier } = Astro.props;
+const { className, identifier } = Astro.props;
 const record = await getEntry("maps", identifier);
 
 const title = record.data.dcMetadata.title_info_primary_tsi;
@@ -18,6 +19,7 @@ const image = `https://bpldcassets.blob.core.windows.net/derivatives/images/${re
 
 <LazyCard
   client:visible
+  className={className}
   title={title}
   subtitle={subtitle}
   link={{

--- a/src/components/CollectionGrid.astro
+++ b/src/components/CollectionGrid.astro
@@ -2,16 +2,16 @@
 import CollectionCard from "@components/CollectionCard.astro";
 
 interface Props {
-  results: array;
+  identifiers: array;
 }
 
-const { results } = Astro.props;
+const { identifiers } = Astro.props;
 ---
 
 <ul class="flex gap-y-5 flex-wrap p-0 list-none filter-list -mx-5 lg:gap-y-10">
-  {results.map((result) => (
+  {identifiers.map((identifier) => (
     <li class="filter-result flex w-full px-5 lg:w-1/3">
-      <CollectionCard identifier={result} />
+      <CollectionCard identifier={identifier} />
     </li>
   ))}
 </ul>

--- a/src/content/stories/george-washingtons-maps.mdx
+++ b/src/content/stories/george-washingtons-maps.mdx
@@ -5,39 +5,43 @@ banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:q524nf40
 author: "Alexandra Montgomery"
 ---
 
-import CollectionCard from "@components/CollectionCard.astro"
+import CollectionGrid from "@components/CollectionGrid.astro"
 
 These are GW's maps.
 
-<CollectionCard identifier="commonwealth:q524nf390" />
-<CollectionCard identifier="commonwealth:q524nk670" />
-<CollectionCard identifier="commonwealth:q524nf43k" />
-<CollectionCard identifier="commonwealth:q524nf454" />
-<CollectionCard identifier="commonwealth:q524nk69j" />
-<CollectionCard identifier="commonwealth:q524nk71k" />
-<CollectionCard identifier="commonwealth:q524nf144" />
-<CollectionCard identifier="commonwealth:q524nd63v" />
-<CollectionCard identifier="commonwealth:q524nf411" />
-<CollectionCard identifier="commonwealth:9s161g59k" />
-<CollectionCard identifier="commonwealth:w9505s84p" />
-<CollectionCard identifier="commonwealth:z603vg752" />
-<CollectionCard identifier="commonwealth:3f462v25m" />
-<CollectionCard identifier="commonwealth:8049g926b" />
-<CollectionCard identifier="commonwealth:kk91fr16h" />
-<CollectionCard identifier="commonwealth:z603vh45j" />
-<CollectionCard identifier="commonwealth:z603vt355" />
-<CollectionCard identifier="commonwealth:6t053n77m" />
-<CollectionCard identifier="commonwealth:q524mv32c" />
-<CollectionCard identifier="commonwealth:kk91fq60v" />
-<CollectionCard identifier="commonwealth:8049g9430" />
-<CollectionCard identifier="commonwealth:z603vr778" />
-<CollectionCard identifier="commonwealth:x633fb36r" />
-<CollectionCard identifier="commonwealth:z603vg02j" />
-<CollectionCard identifier="commonwealth:z603vq683" />
-<CollectionCard identifier="commonwealth:z603vq38c" />
-<CollectionCard identifier="commonwealth:z603vs082" />
-<CollectionCard identifier="commonwealth:q524n4793" />
-<CollectionCard identifier="commonwealth:9s161b907" />
-<CollectionCard identifier="commonwealth:z603vr10w" />
-<CollectionCard identifier="commonwealth:6t053p46t" />
-<CollectionCard identifier="commonwealth:z603vs34p" />
+<CollectionGrid
+    identifiers={[
+        "commonwealth:q524nf390",
+        "commonwealth:q524nk670",
+        "commonwealth:q524nf43k",
+        "commonwealth:q524nf454",
+        "commonwealth:q524nk69j",
+        "commonwealth:q524nk71k",
+        "commonwealth:q524nf144",
+        "commonwealth:q524nd63v",
+        "commonwealth:q524nf411",
+        "commonwealth:9s161g59k",
+        "commonwealth:w9505s84p",
+        "commonwealth:z603vg752",
+        "commonwealth:3f462v25m",
+        "commonwealth:8049g926b",
+        "commonwealth:kk91fr16h",
+        "commonwealth:z603vh45j",
+        "commonwealth:z603vt355",
+        "commonwealth:6t053n77m",
+        "commonwealth:q524mv32c",
+        "commonwealth:kk91fq60v",
+        "commonwealth:8049g9430",
+        "commonwealth:z603vr778",
+        "commonwealth:x633fb36r",
+        "commonwealth:z603vg02j",
+        "commonwealth:z603vq683",
+        "commonwealth:z603vq38c",
+        "commonwealth:z603vs082",
+        "commonwealth:q524n4793",
+        "commonwealth:9s161b907",
+        "commonwealth:z603vr10w",
+        "commonwealth:6t053p46t",
+        "commonwealth:z603vs34p"
+    ]}
+/>

--- a/src/pages/facets/[facet]/[category].astro
+++ b/src/pages/facets/[facet]/[category].astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from "@layouts/BaseLayout.astro";
 import FacetHeader from "@components/FacetHeader.astro";
-import FacetGrid from "@components/FacetGrid.astro";
+import CollectionGrid from "@components/CollectionGrid.astro";
 
 // Generate a new path for every collection entry
 export async function getStaticPaths() {
@@ -31,6 +31,6 @@ const results = entry.entries;
   <div class="filter">
     <FacetHeader facet={facet} facetCategories={facetCategories} currentFacetCategory={entry} />
     <h2 class="text-xl mt-6 font-semibold">Maps</h2>
-    <FacetGrid results={results} />
+    <CollectionGrid identifiers={results} />
   </div>
 </BaseLayout>

--- a/src/pages/facets/[facet]/index.astro
+++ b/src/pages/facets/[facet]/index.astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from "@layouts/BaseLayout.astro";
 import FacetHeader from "@components/FacetHeader.astro";
-import FacetGrid from "@components/FacetGrid.astro";
+import CollectionGrid from "@components/CollectionGrid.astro";
 
 export async function getStaticPaths() {
   const facetEntries = await getCollection('facets');
@@ -23,6 +23,6 @@ facetCategories.forEach((category) => {
   <div class="filter">
     <FacetHeader facet={entry} facetCategories={facetCategories} />
     <h2 class="text-xl mt-6 font-semibold">Maps</h2>
-    <FacetGrid results={results} />
+    <CollectionGrid identifiers={results} />
   </div>
 </BaseLayout>


### PR DESCRIPTION
@garrettdashnelson I have added a `className` attribute for the `CollectionCard` component so you can pass any Tailwind classes directly to the component.

I also added a `CollectionGrid` component, shared with the facet pages if you would like to embed an array of identifiers in a story/markdown template.