### PR TITLE
implement external manifests while hotfixing DC manifests

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -59,6 +59,7 @@ const maps = defineCollection({
             subject_geographic_sim: z.array(z.string()).optional(),
             date_facet_yearly_itim: z.array(z.number()),
             score: z.number(),
+            identifier_iiif_manifest_ss: z.string().optional()
         }),
     }),
 })

--- a/src/pages/maps/[identifier].astro
+++ b/src/pages/maps/[identifier].astro
@@ -16,7 +16,9 @@ export async function getStaticPaths() {
 
 const data = Astro.props.data;
 const title = data.dcMetadata.title_info_primary_tsi;
-const viewerManifest = 'https://collections.leventhalmap.org/search/' + data.dcMetadata.id + '/manifest.json';
+
+// temporary fix to manually handle Digital Commonwealth manifests while ARK redirects are still not working with Clover-IIIF
+const viewerManifest =  data.dcMetadata.identifier_iiif_manifest_ss.includes('ark.digitalcommonwealth') ? 'https://collections.leventhalmap.org/search/' + data.dcMetadata.id + '/manifest.json' : data.dcMetadata.identifier_iiif_manifest_ss;
 
 data.dcMetadata.facetCategories = [];
 
@@ -111,7 +113,7 @@ facetEntries.forEach((facet) => {
             <h2 class="text-xl mb-1">Digital Library</h2>
             <div class="flex flex-wrap gap-x-1 gap-y-2">
               <a
-                href={`https://collections.leventhalmap.org/search/${data.dcMetadata.id}/manifest.json`}
+                href={viewerManifest}
                 target="_blank"
                 class="button arrow"
                 >IIIF Manifest</a


### PR DESCRIPTION
@alexandergknoll - There's a new change to the repository data regarding IIIF Manifests; the `dcMetadata` now includes a `identifier_iiif_manifest_ss` field which should be the canonical source of the collection item's Manifest. This allows us to fully load the images on maps where the imagery is being hosted by an external partner collection, e.g. the University of Michigan. _However_, the `identifier_iiif_manifest_ss` for Digital Commonwealth-hosted collection items will show the ARK perma-id, which as we know isn't currently working in the Clover-IIIF viewer due to the redirect handling. For now, I've fixed it this way: if the `identifier_iiif_manifest_ss` _isn't_ in the ark.digitalcommonwealth namespace, then we use it and pass it on to the `MapViewer` component, whereas if it _is_ in that namespace we rewrite it to the one that we know works.

LMK if you have any ideas or improvements before I merge this in.