### PR TITLE
add facet categories option to collection grid

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -4,7 +4,7 @@
     :class="className"
     v-if="loaded"
   >
-    <div class="relative w-full aspect-video border-b border-bismark-500">
+    <div v-if="image" class="relative w-full aspect-video border-b border-bismark-500">
       <img
         :src="image"
         :alt="title"

--- a/src/components/Cards/FacetCategories.astro
+++ b/src/components/Cards/FacetCategories.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from "astro:content";
+import Card from "@components/Card.vue";
+
+interface Props {
+  className: string;
+  columnClassName: string;
+  identifiers: array;
+}
+
+const { className, columnClassName, identifiers } = Astro.props;
+let entries = [];
+let facetEntries = await getCollection('facets');
+facetEntries = facetEntries.filter((entry) => (
+  identifiers.includes(entry.id)
+));
+facetEntries.forEach((entry) => {
+  let categories = entry.data['facet-categories'];
+  categories = categories.map((category) => {
+    category.facetId = entry.id;
+    return category;
+  })
+
+  entries = entries.concat(categories);
+});
+---
+
+{entries.map((entry) => (
+  <li class={`flex w-full px-5 ${columnClassName}`}>
+    <Card
+      client:visible
+      className={className}
+      title={entry.title}
+      subtitle={`${entry.entries.length} items`}
+      link={{
+        href: `/facets/${entry.facetId}/${entry.id}`,
+        text: "Read more"
+      }}
+    />
+  </li>
+))}

--- a/src/components/CollectionGrid.astro
+++ b/src/components/CollectionGrid.astro
@@ -1,7 +1,7 @@
 ---
 import FacetCard from "@components/Cards/Facet.astro";
+import FacetCategoryCards from "@components/Cards/FacetCategories.astro";
 import MapCard from "@components/Cards/Map.astro";
-import PartnerCollection from "@components/Cards/PartnerCollection.astro";
 import PartnerCollectionCard from "@components/Cards/PartnerCollection.astro";
 import PersonCard from "@components/Cards/Person.astro";
 import StoryCard from "@components/Cards/Story.astro";
@@ -27,26 +27,33 @@ switch (columns) {
     columnClassName = "lg:w-1/3";
     break;
   case 4:
-    columnClassName = "lg:w-1/4";
+    columnClassName = "sm:w-1/2 lg:w-1/4";
     break;
   case 5:
-    columnClassName = "lg:w-1/5";
+    columnClassName = "sm:w-1/3 md:w-1/4 lg:w-1/5";
     break;
   case 6:
-    columnClassName = "lg:w-1/6";
+    columnClassName = "sm:w-1/3 md:w-1/4 lg:w-1/5 xl:w-1/6";
     break;
 }
 ---
 
 {title &&
-  <h2 class="">
+  <h2 class="font-heading font-semibold text-4xl mb-4">
     {title}
   </h2>
 }
 
 <ul class={`flex gap-y-5 flex-wrap p-0 list-none filter-list -mx-5 lg:gap-y-10 ${className}`}>
+  {contentType === 'facetCategories' &&
+    <FacetCategoryCards
+      className={cardClassName}
+      columnClassName={columnClassName}
+      identifiers={identifiers}
+    />
+  }
   {identifiers.map((identifier) => (
-    <li class={`filter-result flex w-full px-5 ${columnClassName}`}>
+    <li class={`flex w-full px-5 ${columnClassName}`}>
       {contentType === 'facets' &&
         <FacetCard
           className={cardClassName}
@@ -60,7 +67,7 @@ switch (columns) {
         />
       }
       {contentType === 'partner-collection' &&
-        <PartnerCollection
+        <PartnerCollectionCard
           className={cardClassName}
           identifier={identifier}
         />

--- a/src/components/Layout/Homepage/Timeline.vue
+++ b/src/components/Layout/Homepage/Timeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['explore-by explore-by-outer explore-by-timelines', { 'explore-by-timelines-active': show_pane }]">
+  <div class="mb-12" :class="['explore-by explore-by-outer explore-by-timelines', { 'explore-by-timelines-active': show_pane }]">
     <div class="filter-explore-by relative mb-4">
       <h2 class="font-heading font-semibold text-4xl mb-4">Explore by Timelines</h2>
       <ul class="flex flex-wrap gap-1">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,32 @@
 ---
-import { getEntry } from "astro:content";
+import { getCollection, getEntry } from 'astro:content';
 
 import BaseLayout from "@layouts/BaseLayout.astro";
-import Title from '@components/Layout/Title.astro';
 import SearchHero from '@components/Layout/Homepage/SearchHero.astro'
 import Timeline from '@components/Layout/Homepage/Timeline.vue'
+import CollectionGrid from "@components/CollectionGrid.astro";
 
 const title = 'Home';
 const timelineData = await getEntry("timeline", "timeline");
+
+const storyEntries = await getCollection('stories');
+const storyIdentifiers = storyEntries.map((entry) => (
+  entry.slug
+));
+
+const facetEntries = await getCollection('facets');
+const facetIdentifiers = facetEntries.map((entry) => (
+  entry.id
+));
 ---
 
 <BaseLayout title={title}>
   <SearchHero />
+  <CollectionGrid className="mb-12" title="Explore by Story" contentType="stories" columns={3} identifiers={storyIdentifiers} />
+  <CollectionGrid className="mb-12" title="Explore by Theme" contentType="facets" columns={4} identifiers={facetIdentifiers} />
   <Timeline data={timelineData.data} client:load />
+  <CollectionGrid className="mb-12" title="Explore by Empires & Nations" contentType="facetCategories" columns={5} identifiers={['empires-and-nations']} />
+  <CollectionGrid className="mb-12" title="Explore by Features" contentType="facetCategories" columns={5} identifiers={['features']} />
+  <CollectionGrid className="mb-12" title="Explore by Languages" contentType="facetCategories" columns={5} identifiers={['languages']} />
+  <CollectionGrid className="mb-12" title="Explore by Subject" contentType="facetCategories" columns={5} identifiers={['subjects']} />
 </BaseLayout>


### PR DESCRIPTION
@garrettdashnelson a few quick notes on this one:

- I added this functionality onto the `CollectionGrid` component.  Would you also like to have carousel functionality such as on the existing site?  If so, I will probably create a separate component for that so we have the option.
- Facet categories do not have images right now, so I have not included a banner image on each card.
- Let me know if you would like me to bring in other alternative card styles to style more closely to the home page on the existing site.