### PR TITLE
Footer cleanup

### DIFF
--- a/src/components/Layout/Footer/Menu.astro
+++ b/src/components/Layout/Footer/Menu.astro
@@ -3,9 +3,9 @@ import { getCollection } from "astro:content";
 import MenuDropdown from '@components/Layout/Footer/MenuDropdown.astro';
 const storyEntries = (await getCollection('stories')).sort(
   (a, b) => b.data.publish_date - a.data.publish_date
-).slice(0, 3);
+);
 
-const recentStoriesLinks = storyEntries.map((entry) => (
+const recentStoriesLinks = storyEntries.slice(0, 3).map((entry) => (
   {
     href: `/stories/${entry.slug}`,
     text: entry.data.title,

--- a/src/components/Layout/Footer/Menu.astro
+++ b/src/components/Layout/Footer/Menu.astro
@@ -1,23 +1,21 @@
 ---
+import { getCollection } from "astro:content";
 import MenuDropdown from '@components/Layout/Footer/MenuDropdown.astro';
+const storyEntries = (await getCollection('stories')).sort(
+  (a, b) => b.data.publish_date - a.data.publish_date
+).slice(0, 3);
+
+const recentStoriesLinks = storyEntries.map((entry) => (
+  {
+    href: `/stories/${entry.slug}`,
+    text: entry.data.title,
+  }
+));
 const dropdowns = [
   {
     href: '/stories/',
     text: 'Recent Stories',
-    links: [
-      {
-        href: '/stories/forgotten-theater/',
-        text: 'The Forgotten Theater of the American Revolution'
-      },
-      {
-        href: '/stories/mapping-american-revolution-symposium/',
-        text: 'Mapping the Revolution'
-      },
-      {
-        href: '/stories/george-washingtons-maps/',
-        text: 'George Washington’s Maps'
-      }
-    ]
+    links: recentStoriesLinks,
   },
   {
     href: '/facets/',
@@ -48,8 +46,6 @@ const dropdowns = [
       {
         href: '/partner-collections',
         text: 'Partner Collections'
-      }
-    ]
       },
       {
         href: '/educators/',

--- a/src/components/Layout/Footer/Menu.astro
+++ b/src/components/Layout/Footer/Menu.astro
@@ -23,21 +23,17 @@ const dropdowns = [
     href: '/facets/',
     text: 'Featured Themes',
     links: [
+    {
+        href: '/facets/',
+        text: 'Themes'
+      },
       {
         href: '/people/',
         text: 'People'
       },
       {
-        href: '/facets/empires-and-nations/',
-        text: 'Nations & Empires'
-      },
-      {
-        href: '/facets/features/cartouche/',
-        text: 'Cartouches'
-      },
-      {
-        href: '/facets/features/animal/',
-        text: 'Animals'
+        href: '/partner-collections/',
+        text: 'Partner Collections'
       }
     ]
   },
@@ -54,10 +50,12 @@ const dropdowns = [
         text: 'Partner Collections'
       }
     ]
-  },
-  {
-    href: '/educators/',
-    text: 'For Educators',
+      },
+      {
+        href: '/educators/',
+        text: 'For Educators',
+      }
+    ]
   }
 ]
 ---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -83,7 +83,8 @@ const stories = defineCollection({
         title: z.string(),
         short_description: z.string(),
         banner_image: z.string().url(),
-        author: z.string()
+        author: z.string(),
+        publish_date: z.date(),
     }),
 });
 

--- a/src/content/stories/forgotten-theater.mdx
+++ b/src/content/stories/forgotten-theater.mdx
@@ -3,6 +3,7 @@ title: "Aquidneck Island: The Forgotten Theater of the American Revolution"
 short_description: "Dive into the history of Aquidneck Island, an important tactical position off the coast of Rhode Island that was occupied by British, French, and American troops throughout the Revolution."
 banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:q524nd57q/3326,658,3138,1428/,1200/0/default.jpg"
 author: "Paige Duplaise"
+publish_date: 2024-03-02
 ---
 
 <iframe src="https://www.exhibit.so/exhibits/SmDX3j9Bl8e0qRwg4yai?embedded=true" allowfullscreen allow="autoplay" frameborder="0" style="width:100%;height:70vh"></iframe>

--- a/src/content/stories/george-washingtons-maps.mdx
+++ b/src/content/stories/george-washingtons-maps.mdx
@@ -3,6 +3,7 @@ title: "George Washington's Maps"
 short_description: "Maps made by George Washington and copies of maps known to have been owned by him"
 banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:q524nf40r/116,1201,3537,1638/,1200/0/default.jpg"
 author: "Alexandra Montgomery"
+publish_date: 2024-02-29
 ---
 
 import CollectionGrid from "@components/CollectionGrid.astro"

--- a/src/content/stories/map-genres.mdx
+++ b/src/content/stories/map-genres.mdx
@@ -3,6 +3,7 @@ title: "Map Genres: What Types of Maps are Included in the ARGO Portal?"
 short_description: "Learn more about the kinds of maps included in the ARGO portal"
 banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:z603vw05v/5855,8369,2875,968/pct:50/0/default.jpg"
 author: "Ron Grim"
+publish_date: 2024-02-28
 ---
 import CollectionGrid from "@components/CollectionGrid.astro"
 

--- a/src/content/stories/mapping-american-revolution-symposium.mdx
+++ b/src/content/stories/mapping-american-revolution-symposium.mdx
@@ -3,6 +3,7 @@ title: "Mapping the American Revolution Symposium"
 short_description: "Maps relating to the November 2022 Mount Vernon George Washington Symposium, Mapping the American Revolution"
 banner_image: "https://a-us.storyblok.com/f/1016535/554x298/28052a9729/mapping_american_revolution.jpg"
 author: "Alexandra Montgomery"
+publish_date: 2024-03-01
 ---
 
 import CollectionGrid from "@components/CollectionGrid.astro"

--- a/src/content/stories/river-gods.mdx
+++ b/src/content/stories/river-gods.mdx
@@ -3,6 +3,7 @@ title: "The World of the River Gods in Colonial New England"
 short_description: "Read Nathaniel Dwight's story and learn about the political power and influence of the River Gods"
 banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:6108vt051/351,1559,2140,1585/pct:50/0/default.jpg"
 author: "Sam Dinnie"
+publish_date: 2024-02-27
 ---
 
 Eighteenth-century society in the Connecticut River Valley of Massachusetts was dominated by the River Gods. Regarded by contemporaries as “the old established gentry of Western Massachusetts, connected by blood and friendship,” the River God clan functioned as an aristocracy in which belonging was predicated upon birth or marriage into the seven River God bloodlines: Ashley, Dwight, Partridge, Porter, Pynchon, Stoddard, and Williams.[^1]<br/>


### PR DESCRIPTION
The only question I had on this one is whether we want to add an attribute to "Stories" for a menu-friendly label rather than the full title.  For example, what was previously called "The Forgotten Theater of the American Revolution" in the footer is now called "Aquidneck Island: The Forgotten Theater of the American Revolution".