### PR TITLE
Initial working version of frontpage map

### DIFF
--- a/bin/sync_collections.py
+++ b/bin/sync_collections.py
@@ -5,7 +5,9 @@ import os
 complete = False
 page = 1
 
-query = "https://collections.leventhalmap.org/search?utf8=✓&f_inclusive[destination_site_ssim][]=argo&format=json"
+query = "https://collections.leventhalmap.org/search?utf8=✓&f_inclusive[destination_site_ssim][]=argo&format=json&per_page=100"
+
+bboxes = []
 
 def parse_collection_record(doc):
     filename = "../src/content/maps/{}.json".format(doc["id"].replace(":","__"))
@@ -15,12 +17,17 @@ def parse_collection_record(doc):
         jsonContent = {"argoMetadata": {}, "dcMetadata": doc}
         json.dump(jsonContent, f, sort_keys=True, indent=4, separators=(',', ': '))
 
-
+        try:
+            if doc["subject_bbox_geospatial"]:
+                e = {"id": doc["id"], "bbox": doc["subject_bbox_geospatial"][0]}
+                bboxes.append(e)
+        except:
+            pass
 
 
 
 while not complete:
-    print ("Hi")
+    print ("Page")
     r = requests.get("{}&per_page=100&page={}".format(query, page))
 
     j = r.json()
@@ -30,9 +37,11 @@ while not complete:
 
     if j["response"]["pages"]["last_page?"]:
         complete = True
+        
+        with open("../src/content/map-bboxes.json", "w") as f:
+            json.dump(bboxes, f, sort_keys=True, indent=4, separators=(',', ': '))
     else:
         page = page + 1
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro-seo": "^0.8.2",
     "axios": "^1.6.7",
     "debounce": "^2.0.0",
+    "ol": "^9.0.0",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.6.7",
     "debounce": "^2.0.0",
     "ol": "^9.0.0",
+    "ol-mapbox-style": "^12.2.1",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
     "react": "^18.2.0",

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,7 +2,7 @@
 
 /* Typography */
 .heading-underlined {
-	@apply flex;
+	@apply flex leading-tight;
 
 	@screen sm {
     box-shadow: inset 0 1.1em theme("colors.gray.50"),

--- a/src/assets/map-bboxes.json
+++ b/src/assets/map-bboxes.json
@@ -1,0 +1,4022 @@
+[
+    {
+        "bbox": "ENVELOPE(-81.397777, -81.38527, 31.1375, 31.1325)",
+        "id": "commonwealth:hx11z463j"
+    },
+    {
+        "bbox": "ENVELOPE(-81.397777, -81.38527, 31.1375, 31.1325)",
+        "id": "commonwealth:hx11z4610"
+    },
+    {
+        "bbox": "ENVELOPE(-76.086667, -75.740833, 37.172222, 36.868056)",
+        "id": "commonwealth:hx11z2634"
+    },
+    {
+        "bbox": "ENVELOPE(-77.37487154046838, -74.24885829673163, 43.61801086396863, 41.88106953568024)",
+        "id": "commonwealth:z603vg68n"
+    },
+    {
+        "bbox": "ENVELOPE(-76.086667, -75.740833, 37.172222, 36.868056)",
+        "id": "commonwealth:hx11z265p"
+    },
+    {
+        "bbox": "ENVELOPE(-81.397777, -81.38527, 31.1375, 31.1325)",
+        "id": "commonwealth:hx11z529f"
+    },
+    {
+        "bbox": "ENVELOPE(-76.086667, -75.740833, 37.172222, 36.868056)",
+        "id": "commonwealth:hx11z2677"
+    },
+    {
+        "bbox": "ENVELOPE(-76.086667, -75.740833, 37.172222, 36.868056)",
+        "id": "commonwealth:hx11z268h"
+    },
+    {
+        "bbox": "ENVELOPE(-104.79171504764528, -52.29980720023146, 50.88196578015561, 27.920432687394467)",
+        "id": "commonwealth:z603vp92z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.37583119979126, -70.64301548942763, 42.59444667522823, 42.15181551559202)",
+        "id": "commonwealth:cj82m296x"
+    },
+    {
+        "bbox": "ENVELOPE(-74.45431915672901, -73.20766628988964, 41.885087384897865, 40.64272644557316)",
+        "id": "commonwealth:7h149x73k"
+    },
+    {
+        "bbox": "ENVELOPE(-76.566666, -73.66666, 43.46666, 42.75)",
+        "id": "commonwealth:hx11z321t"
+    },
+    {
+        "bbox": "ENVELOPE(-78.927777, -78.84, 42.89583, 42.855)",
+        "id": "commonwealth:hx11z481g"
+    },
+    {
+        "bbox": "ENVELOPE(-62.08452610213843, -59.39291576591939, 47.295756229631586, 45.32495236227408)",
+        "id": "commonwealth:hx11z5064"
+    },
+    {
+        "bbox": "ENVELOPE(-73.475277, -73.35694, 43.8475, 43.79527)",
+        "id": "commonwealth:hx11z5374"
+    },
+    {
+        "bbox": "ENVELOPE(-73.475277, -73.35694, 43.8475, 43.79527)",
+        "id": "commonwealth:hx11z3419"
+    },
+    {
+        "bbox": "ENVELOPE(-73.8, -73.06666, 46.06666, 43.26666)",
+        "id": "commonwealth:hx11z330s"
+    },
+    {
+        "bbox": "ENVELOPE(-83.666666, -78.48333, 43.16666, 39.61666)",
+        "id": "commonwealth:6108vw177"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721944, -73.37944, 43.85972, 43.41638)",
+        "id": "commonwealth:hx11z337q"
+    },
+    {
+        "bbox": "ENVELOPE(-67.74644663268589, -60.29256897743276, 47.280841842426895, 42.85297724369295)",
+        "id": "commonwealth:hx11z4938"
+    },
+    {
+        "bbox": "ENVELOPE(-76.85, -75.0, 40.4, 39.25)",
+        "id": "commonwealth:z603vt11k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.33, -74.29861, 42.67777, 42.65805)",
+        "id": "commonwealth:hx11z355n"
+    },
+    {
+        "bbox": "ENVELOPE(-73.423333, -73.35833, 43.95611, 43.83861)",
+        "id": "commonwealth:hx11z332b"
+    },
+    {
+        "bbox": "ENVELOPE(-73.475277, -73.35694, 43.8475, 43.79527)",
+        "id": "commonwealth:hx11z343v"
+    },
+    {
+        "bbox": "ENVELOPE(-69.633333, -65.71666, 48.2, 45.06666)",
+        "id": "commonwealth:hx11z497c"
+    },
+    {
+        "bbox": "ENVELOPE(-69.633333, -65.71666, 48.2, 45.06666)",
+        "id": "commonwealth:hx11z495t"
+    },
+    {
+        "bbox": "ENVELOPE(-76.511667, -76.502778, 43.47, 43.460556)",
+        "id": "commonwealth:hx11z123z"
+    },
+    {
+        "bbox": "ENVELOPE(-76.511667, -76.502778, 43.47, 43.460556)",
+        "id": "commonwealth:hx11z121d"
+    },
+    {
+        "bbox": "ENVELOPE(-81.415, -81.40666, 31.1225, 31.11777)",
+        "id": "commonwealth:hx11z459z"
+    },
+    {
+        "bbox": "ENVELOPE(-66.383333, -60.8, 47.21666, 43.38333)",
+        "id": "commonwealth:hx11z489p"
+    },
+    {
+        "bbox": "ENVELOPE(-85.02745332732933, -73.36697870167217, 26.854023414732325, 18.10550031362621)",
+        "id": "commonwealth:6t053q82w"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -68.74, 46.9, 42.3)",
+        "id": "commonwealth:7h149z66c"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -68.74, 46.9, 42.3)",
+        "id": "commonwealth:0r96fq74n"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0, -73.0, 44.0, 41.0)",
+        "id": "commonwealth:6t053q240"
+    },
+    {
+        "bbox": "ENVELOPE(-171.95485696130152, 27.001716118132123, 86.26293397104155, -24.596207135739235)",
+        "id": "commonwealth:z603vg61q"
+    },
+    {
+        "bbox": "ENVELOPE(-120.0, -45.0, 55.0, 5.0)",
+        "id": "commonwealth:w9505r63q"
+    },
+    {
+        "bbox": "ENVELOPE(-120.0, -50.0, 55.0, 5.0)",
+        "id": "commonwealth:0r96fq64d"
+    },
+    {
+        "bbox": "ENVELOPE(-73.25, -70.85, 42.0, 40.9)",
+        "id": "commonwealth:j38608291"
+    },
+    {
+        "bbox": "ENVELOPE(-73.25, -70.85, 42.0, 40.9)",
+        "id": "commonwealth:6t053p36k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.4, -73.35, 41.25, 40.4)",
+        "id": "commonwealth:z603vs77g"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -50.0, 55.0, 28.0)",
+        "id": "commonwealth:z603vp41g"
+    },
+    {
+        "bbox": "ENVELOPE(-150.0, -30.0, 70.0, 3.0)",
+        "id": "commonwealth:z603vp431"
+    },
+    {
+        "bbox": "ENVELOPE(-71.5, -70.15, 42.8, 41.8)",
+        "id": "commonwealth:z603vr582"
+    },
+    {
+        "bbox": "ENVELOPE(-71.5, -70.15, 42.8, 41.8)",
+        "id": "commonwealth:wd376564m"
+    },
+    {
+        "bbox": "ENVELOPE(-71.83333, -66.95, 47.45, 42.96666)",
+        "id": "commonwealth:z603vg27d"
+    },
+    {
+        "bbox": "ENVELOPE(-89.0, -68.0, 45.0, 35.0)",
+        "id": "commonwealth:j3860873k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.63276410695505, -67.77636459256875, 46.97861898485856, 39.95024460165664)",
+        "id": "commonwealth:3f462x889"
+    },
+    {
+        "bbox": "ENVELOPE(-96.38333, -65.78333, 49.75, 29.5)",
+        "id": "commonwealth:z603vg930"
+    },
+    {
+        "bbox": "ENVELOPE(-103.07088752687467, -56.930378946045714, 51.29698605307927, 25.00885907693255)",
+        "id": "commonwealth:z603vq82x"
+    },
+    {
+        "bbox": "ENVELOPE(-96.07618507923418, -63.50173751356706, 50.93733645002843, 27.775441217153755)",
+        "id": "commonwealth:wd376496p"
+    },
+    {
+        "bbox": "ENVELOPE(-90.0, -29.0, 9.0, -57.0)",
+        "id": "commonwealth:z603vh27m"
+    },
+    {
+        "bbox": "ENVELOPE(-117.9722298785329, -36.30687333407634, 51.1555729436407, -3.1416444004334636)",
+        "id": "commonwealth:z603vh28w"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -52.0, 32.0, 5.0)",
+        "id": "commonwealth:z603vh17c"
+    },
+    {
+        "bbox": "ENVELOPE(-92.0, -60.0, 30.0, 7.0)",
+        "id": "commonwealth:z603vh32g"
+    },
+    {
+        "bbox": "ENVELOPE(-90.0, -60.0, 30.0, 6.0)",
+        "id": "commonwealth:z603vh18n"
+    },
+    {
+        "bbox": "ENVELOPE(-72.09305449122769, -0.03743498139141366, 42.9744838131362, 0.021266744092137913)",
+        "id": "commonwealth:z603vg07x"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -51.0, 52.0, 28.0)",
+        "id": "commonwealth:z603vs93v"
+    },
+    {
+        "bbox": "ENVELOPE(-165.0, 7.0, 75.0, -60.0)",
+        "id": "commonwealth:z603vn906"
+    },
+    {
+        "bbox": "ENVELOPE(157.0, 97.0, 80.0, -60.0)",
+        "id": "commonwealth:z603vv06x"
+    },
+    {
+        "bbox": "ENVELOPE(-127.5, -4.02, 49.34, -56.35)",
+        "id": "commonwealth:z603vt21t"
+    },
+    {
+        "bbox": "ENVELOPE(-138.0, -38.0, 70.0, -5.0)",
+        "id": "commonwealth:z603vv742"
+    },
+    {
+        "bbox": "ENVELOPE(-120.69351162399627, -46.7523088200046, 55.52243167909096, 0.836127114498602)",
+        "id": "commonwealth:x633f862z"
+    },
+    {
+        "bbox": "ENVELOPE(-106.0, -52.0, 52.0, 28.0)",
+        "id": "commonwealth:dz010v79t"
+    },
+    {
+        "bbox": "ENVELOPE(-125.0, -0.0, 80.0, 5.0)",
+        "id": "commonwealth:z603vq04j"
+    },
+    {
+        "bbox": "ENVELOPE(-125.0, -0.0, 80.0, 5.0)",
+        "id": "commonwealth:z603vq08n"
+    },
+    {
+        "bbox": "ENVELOPE(-150.0, 20.0, 80.0, 0.0)",
+        "id": "commonwealth:z603vv14m"
+    },
+    {
+        "bbox": "ENVELOPE(-120.0, -22.0, 75.0, 0.0)",
+        "id": "commonwealth:z603vt23c"
+    },
+    {
+        "bbox": "ENVELOPE(-155.0, -40.0, 75.0, 5.0)",
+        "id": "commonwealth:z603vv165"
+    },
+    {
+        "bbox": "ENVELOPE(-60.000833, -59.95361, 45.92888, 45.88388)",
+        "id": "commonwealth:hx11z5110"
+    },
+    {
+        "bbox": "ENVELOPE(-74.016667, -70.583333, 47.133333, 45.333333)",
+        "id": "commonwealth:hx11z082x"
+    },
+    {
+        "bbox": "ENVELOPE(-81.11, -80.4, 25.56, 24.39)",
+        "id": "commonwealth:3f462v631"
+    },
+    {
+        "bbox": "ENVELOPE(-66.2722, -65.2807, 44.4621, 44.1152)",
+        "id": "commonwealth:9g54xk69f"
+    },
+    {
+        "bbox": "ENVELOPE(-61.975705447844746, -61.60649521703122, 17.236233938736213, 16.958601452326125)",
+        "id": "commonwealth:6t053r40k"
+    },
+    {
+        "bbox": "ENVELOPE(-61.93, -61.65, 17.19, 16.99)",
+        "id": "commonwealth:q524mt792"
+    },
+    {
+        "bbox": "ENVELOPE(-73.45, -73.2, 44.75, 44.55)",
+        "id": "commonwealth:z603vr71m"
+    },
+    {
+        "bbox": "ENVELOPE(-73.45, -73.2, 44.75, 44.55)",
+        "id": "commonwealth:9s161869k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.1612, -73.42, 40.5857, 40.2926)",
+        "id": "commonwealth:7h149z64t"
+    },
+    {
+        "bbox": "ENVELOPE(-59.67, -59.41, 13.35, 13.02)",
+        "id": "commonwealth:q524mt93w"
+    },
+    {
+        "bbox": "ENVELOPE(-59.69642740485743, -59.37119459314612, 13.395630528315351, 12.969824479205244)",
+        "id": "commonwealth:6t053r34f"
+    },
+    {
+        "bbox": "ENVELOPE(-79.93, -79.8, 32.78, 32.67)",
+        "id": "commonwealth:z603vs38s"
+    },
+    {
+        "bbox": "ENVELOPE(-65.37, -65.3137, 43.3412, 43.2818)",
+        "id": "commonwealth:9g54xk78d"
+    },
+    {
+        "bbox": "ENVELOPE(-66.28, -64.05, 48.55, 47.26)",
+        "id": "commonwealth:7h149v582"
+    },
+    {
+        "bbox": "ENVELOPE(-66.3953, -66.1229, 50.18, 50.0434)",
+        "id": "commonwealth:7h149v47j"
+    },
+    {
+        "bbox": "ENVELOPE(-76.65, -74.6, 39.45, 36.65)",
+        "id": "commonwealth:z603vv10h"
+    },
+    {
+        "bbox": "ENVELOPE(-74.29, -73.84, 40.79, 40.37)",
+        "id": "commonwealth:j3860849h"
+    },
+    {
+        "bbox": "ENVELOPE(-61.3, -61.2, 13.05, 12.98)",
+        "id": "commonwealth:q524mt813"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07339657708327, -71.02530700676935, 42.37289078982551, 42.335020253203304)",
+        "id": "commonwealth:3f462x39c"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.01, 42.39, 42.33)",
+        "id": "commonwealth:dz010v603"
+    },
+    {
+        "bbox": "ENVELOPE(-71.12, -70.94, 42.39, 42.31)",
+        "id": "commonwealth:q524n418c"
+    },
+    {
+        "bbox": "ENVELOPE(-75.07875150004897, -69.3393910098857, 45.13504386133586, 40.127045284991055)",
+        "id": "commonwealth:6t053p295"
+    },
+    {
+        "bbox": "ENVELOPE(-120.0, -45.0, 54.0, 4.0)",
+        "id": "commonwealth:z603vt96w"
+    },
+    {
+        "bbox": "ENVELOPE(-74.25, -69.25, 44.5, 40.25)",
+        "id": "commonwealth:hq37vv762"
+    },
+    {
+        "bbox": "ENVELOPE(-93.683333, -51.816667, 51.783333, 25.166667)",
+        "id": "commonwealth:hx11xz52t"
+    },
+    {
+        "bbox": "ENVELOPE(-99.0, -51.85, 53.0, 28.5)",
+        "id": "commonwealth:w9505s74f"
+    },
+    {
+        "bbox": "ENVELOPE(-70.5907, -70.3632, 41.4542, 41.1756)",
+        "id": "commonwealth:7h149w46g"
+    },
+    {
+        "bbox": "ENVELOPE(-70.5907, -70.3632, 41.4542, 41.1756)",
+        "id": "commonwealth:7h149z55v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.01, 42.39, 42.33)",
+        "id": "commonwealth:dz010v62n"
+    },
+    {
+        "bbox": "ENVELOPE(-101.666667, -51.85, 52.683333, 24.65)",
+        "id": "commonwealth:hx11xz37q"
+    },
+    {
+        "bbox": "ENVELOPE(-101.666667, -51.85, 52.683333, 24.65)",
+        "id": "commonwealth:hx11xz355"
+    },
+    {
+        "bbox": "ENVELOPE(-65.0, -51.0, 20.0, 3.5)",
+        "id": "commonwealth:q524mt856"
+    },
+    {
+        "bbox": "ENVELOPE(-78.0, -75.42, 39.78, 36.62)",
+        "id": "commonwealth:cj82kx887"
+    },
+    {
+        "bbox": "ENVELOPE(-74.3, -73.85, 40.8, 40.35)",
+        "id": "commonwealth:1257bb63q"
+    },
+    {
+        "bbox": "ENVELOPE(-104.0, -68.0, 47.0, 24.0)",
+        "id": "commonwealth:x059gf098"
+    },
+    {
+        "bbox": "ENVELOPE(-79.3, -69.6, 45.0, 39.25)",
+        "id": "commonwealth:hq37vv40p"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0, -65.0, 45.0, 40.0)",
+        "id": "commonwealth:j38608754"
+    },
+    {
+        "bbox": "ENVELOPE(-77.25589367993665, -74.85729204681742, 38.48413842415046, 36.52990764047908)",
+        "id": "commonwealth:z603vs53w"
+    },
+    {
+        "bbox": "ENVELOPE(-83.20709488252713, -72.50659350932877, 42.71295279260588, 37.84357811182642)",
+        "id": "commonwealth:6t053p23h"
+    },
+    {
+        "bbox": "ENVELOPE(-75.516667, -73.816667, 45.483333, 44.683333)",
+        "id": "commonwealth:hx11z1425"
+    },
+    {
+        "bbox": "ENVELOPE(-95.5, -47.78, 52.7, 25.0)",
+        "id": "commonwealth:z603vs42c"
+    },
+    {
+        "bbox": "ENVELOPE(-59.67, -59.4, 13.35, 13.03)",
+        "id": "commonwealth:6t053r360"
+    },
+    {
+        "bbox": "ENVELOPE(-61.82, -61.57, 12.25, 12.0)",
+        "id": "commonwealth:6t053r246"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0, -69.0, 20.0, 17.0)",
+        "id": "commonwealth:6t053q94p"
+    },
+    {
+        "bbox": "ENVELOPE(-82.2, -77.9, 40.8, 38.0)",
+        "id": "commonwealth:q524mv05g"
+    },
+    {
+        "bbox": "ENVELOPE(-101.0, -66.0, 48.0, 28.0)",
+        "id": "commonwealth:z603vr04r"
+    },
+    {
+        "bbox": "ENVELOPE(-95.0, -62.0, 49.0, 29.0)",
+        "id": "commonwealth:z603vs99h"
+    },
+    {
+        "bbox": "ENVELOPE(-95.5, -49.75, 52.3, 28.8)",
+        "id": "commonwealth:z603vr88s"
+    },
+    {
+        "bbox": "ENVELOPE(-95.5, -49.75, 52.3, 28.8)",
+        "id": "commonwealth:w9505s80k"
+    },
+    {
+        "bbox": "ENVELOPE(-78.33, -68.33, 20.18, 17.55)",
+        "id": "commonwealth:x633f9871"
+    },
+    {
+        "bbox": "ENVELOPE(-95.9, -51.55, 51.9, 28.75)",
+        "id": "commonwealth:z603vs61k"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -52.0, 52.0, 28.0)",
+        "id": "commonwealth:td96p832s"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -57.0, 52.0, 36.0)",
+        "id": "commonwealth:z603vt19s"
+    },
+    {
+        "bbox": "ENVELOPE(-97.0, -65.0, 37.0, 16.0)",
+        "id": "commonwealth:z603vn443"
+    },
+    {
+        "bbox": "ENVELOPE(-88.116667, -76.7, 43.15, 37.716667)",
+        "id": "commonwealth:hx11z213x"
+    },
+    {
+        "bbox": "ENVELOPE(-103.60902241547075, -36.82862585976801, 37.47125294495649, 2.552641428020671)",
+        "id": "commonwealth:6t053r80j"
+    },
+    {
+        "bbox": "ENVELOPE(-74.266667, -71.95, 46.533333, 44.166667)",
+        "id": "commonwealth:hx11z060w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.6, -73.033333, 45.45, 43.883333)",
+        "id": "commonwealth:hx11z180k"
+    },
+    {
+        "bbox": "ENVELOPE(-79.983333, -75.96666, 44.3, 43.06666)",
+        "id": "commonwealth:hx11z323c"
+    },
+    {
+        "bbox": "ENVELOPE(-71.15394190692678, -70.91399070304466, 42.42929130121076, 42.26641865879526)",
+        "id": "commonwealth:t722hs83w"
+    },
+    {
+        "bbox": "ENVELOPE(-78.15, -69.55, 47.0, 37.8)",
+        "id": "commonwealth:z603vs97z"
+    },
+    {
+        "bbox": "ENVELOPE(-80.0, -72.0, 45.0, 38.0)",
+        "id": "commonwealth:z603vt68q"
+    },
+    {
+        "bbox": "ENVELOPE(-88.75, -54.6, 52.1, 30.0)",
+        "id": "commonwealth:z603vs16r"
+    },
+    {
+        "bbox": "ENVELOPE(-81.0, -52.0, 53.0, 36.0)",
+        "id": "commonwealth:z603vv122"
+    },
+    {
+        "bbox": "ENVELOPE(-50.0, -50.0, 55.0, 15.0)",
+        "id": "commonwealth:z603vp627"
+    },
+    {
+        "bbox": "ENVELOPE(-98.0, -53.0, 51.0, 28.0)",
+        "id": "commonwealth:z603vw22h"
+    },
+    {
+        "bbox": "ENVELOPE(-96.0, -52.0, 53.0, 28.0)",
+        "id": "commonwealth:3f462x73p"
+    },
+    {
+        "bbox": "ENVELOPE(-96.0, -52.0, 53.0, 28.0)",
+        "id": "commonwealth:8049g937v"
+    },
+    {
+        "bbox": "ENVELOPE(-59.4655516634565, -57.48803744808568, 7.802137506796732, 5.7919344574630465)",
+        "id": "commonwealth:xg94j1060"
+    },
+    {
+        "bbox": "ENVELOPE(-80.0, -49.5, 52.4, 29.1)",
+        "id": "commonwealth:z603vs55f"
+    },
+    {
+        "bbox": "ENVELOPE(-76.65, -75.416667, 44.733333, 43.816667)",
+        "id": "commonwealth:hx11z0968"
+    },
+    {
+        "bbox": "ENVELOPE(-79.883333, -76.033333, 44.266667, 42.933333)",
+        "id": "commonwealth:hx11z088k"
+    },
+    {
+        "bbox": "ENVELOPE(-60.07, -59.95, 45.93, 45.87)",
+        "id": "commonwealth:z603vw128"
+    },
+    {
+        "bbox": "ENVELOPE(-80.1075, -79.693889, 32.863611, 32.585556)",
+        "id": "commonwealth:hx11z270j"
+    },
+    {
+        "bbox": "ENVELOPE(-79.973889, -79.903333, 32.805, 32.764444)",
+        "id": "commonwealth:hx11z2723"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.01, 42.39, 42.33)",
+        "id": "commonwealth:dz010v646"
+    },
+    {
+        "bbox": "ENVELOPE(-64.0527, -63.5024, 44.4146, 44.28)",
+        "id": "commonwealth:9g54xk98w"
+    },
+    {
+        "bbox": "ENVELOPE(-74.3, -73.8, 40.9, 40.35)",
+        "id": "commonwealth:j3860821t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.3, -73.8, 40.9, 40.35)",
+        "id": "commonwealth:wd3768451"
+    },
+    {
+        "bbox": "ENVELOPE(-107.58, 3.58, 82.0, 50.0)",
+        "id": "commonwealth:q524mv59s"
+    },
+    {
+        "bbox": "ENVELOPE(154.0, -107.58, 60.0, 0.0)",
+        "id": "commonwealth:q524mv60j"
+    },
+    {
+        "bbox": "ENVELOPE(156.0, -107.58, -0.0, -60.0)",
+        "id": "commonwealth:q524mv623"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -69.0, 44.0, 38.0)",
+        "id": "commonwealth:j3860877p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1217, -70.4225, 42.322, 42.1138)",
+        "id": "commonwealth:3f462w09f"
+    },
+    {
+        "bbox": "ENVELOPE(-71.20155832038279, -70.81594065732429, 42.45256271899864, 42.25177815879449)",
+        "id": "commonwealth:z603vg02j"
+    },
+    {
+        "bbox": "ENVELOPE(-64.29, -59.36, 47.51, 45.24)",
+        "id": "commonwealth:7h149v981"
+    },
+    {
+        "bbox": "ENVELOPE(-75.29, -74.5, 39.19, 38.32)",
+        "id": "commonwealth:z603vv27p"
+    },
+    {
+        "bbox": "ENVELOPE(-75.2341, -74.582, 40.0043, 39.4847)",
+        "id": "commonwealth:z603vv297"
+    },
+    {
+        "bbox": "ENVELOPE(-77.5723, -77.5459, 18.2859, 18.2614)",
+        "id": "commonwealth:7h149x91h"
+    },
+    {
+        "bbox": "ENVELOPE(-70.363, -69.5555, 41.2912, 41.1251)",
+        "id": "commonwealth:7h149z539"
+    },
+    {
+        "bbox": "ENVELOPE(-74.1028, -73.5554, 40.4358, 40.2255)",
+        "id": "commonwealth:z603vv211"
+    },
+    {
+        "bbox": "ENVELOPE(158.5, -107.5, 82.0, 60.0)",
+        "id": "commonwealth:q524mt59k"
+    },
+    {
+        "bbox": "ENVELOPE(-66.55, -59.37, 46.11, 43.11)",
+        "id": "commonwealth:3f462v92g"
+    },
+    {
+        "bbox": "ENVELOPE(-70.4406, -70.3539, 42.0349, 41.5613)",
+        "id": "commonwealth:3f4639492"
+    },
+    {
+        "bbox": "ENVELOPE(-70.4406, -70.3539, 42.0349, 41.5613)",
+        "id": "commonwealth:3f463952c"
+    },
+    {
+        "bbox": "ENVELOPE(-70.4406, -70.3539, 42.0349, 41.5613)",
+        "id": "commonwealth:3f463950t"
+    },
+    {
+        "bbox": "ENVELOPE(-76.5453, -76.3947, 18.0109, 17.5411)",
+        "id": "commonwealth:7h149x87x"
+    },
+    {
+        "bbox": "ENVELOPE(-107.58, 3.0, 23.0, -60.0)",
+        "id": "commonwealth:q524mv63c"
+    },
+    {
+        "bbox": "ENVELOPE(-107.58, 3.0, 23.0, -60.0)",
+        "id": "commonwealth:q524n451d"
+    },
+    {
+        "bbox": "ENVELOPE(-107.58, 5.0, 66.0, -3.0)",
+        "id": "commonwealth:q524mv61t"
+    },
+    {
+        "bbox": "ENVELOPE(-54.75, -46.1, 49.85, 39.0)",
+        "id": "commonwealth:q524mv24p"
+    },
+    {
+        "bbox": "ENVELOPE(-87.1933, -86.5036, 30.3541, 30.1825)",
+        "id": "commonwealth:z603vv386"
+    },
+    {
+        "bbox": "ENVELOPE(-77.25, -75.25, 36.0, 33.75)",
+        "id": "commonwealth:cj82m718k"
+    },
+    {
+        "bbox": "ENVELOPE(-78.75, -76.75, 35.0, 32.5)",
+        "id": "commonwealth:cj82m7225"
+    },
+    {
+        "bbox": "ENVELOPE(-80.25, -78.5, 34.75, 32.25)",
+        "id": "commonwealth:cj82m720m"
+    },
+    {
+        "bbox": "ENVELOPE(-77.25, -74.25, 37.5, 36.0)",
+        "id": "commonwealth:cj82m7161"
+    },
+    {
+        "bbox": "ENVELOPE(-81.75, -79.75, 32.5, 29.5)",
+        "id": "commonwealth:cj82m7268"
+    },
+    {
+        "bbox": "ENVELOPE(-81.25, -79.25, 30.0, 27.5)",
+        "id": "commonwealth:cj82m724q"
+    },
+    {
+        "bbox": "ENVELOPE(-70.35, -67.55, 44.7, 43.4)",
+        "id": "commonwealth:3f462z05r"
+    },
+    {
+        "bbox": "ENVELOPE(-70.25, -68.5, 44.75, 43.4)",
+        "id": "commonwealth:3f462z282"
+    },
+    {
+        "bbox": "ENVELOPE(-80.75, -79.0, 27.5, 24.75)",
+        "id": "commonwealth:cj82m728t"
+    },
+    {
+        "bbox": "ENVELOPE(-81.75, -79.0, 24.75, 23.0)",
+        "id": "commonwealth:cj82m730v"
+    },
+    {
+        "bbox": "ENVELOPE(-81.51, -79.55, 32.42, 30.37)",
+        "id": "commonwealth:z603vv32j"
+    },
+    {
+        "bbox": "ENVELOPE(-81.51, -79.55, 32.42, 30.37)",
+        "id": "commonwealth:z603vv343"
+    },
+    {
+        "bbox": "ENVELOPE(-77.3, -73.24, 40.5, 34.25)",
+        "id": "commonwealth:7h149x34w"
+    },
+    {
+        "bbox": "ENVELOPE(-64.2356, -62.5454, 50.2022, 50.1016)",
+        "id": "commonwealth:7h149v493"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -58.28, 50.04, 46.42)",
+        "id": "commonwealth:7h149v38k"
+    },
+    {
+        "bbox": "ENVELOPE(-90.0, -35.0, 70.0, 25.0)",
+        "id": "commonwealth:j38608797"
+    },
+    {
+        "bbox": "ENVELOPE(-95.0, -0.0, 58.0, 10.0)",
+        "id": "commonwealth:z603vr468"
+    },
+    {
+        "bbox": "ENVELOPE(-71.16585677085216, -70.79611475439698, 42.43459525495263, 42.23334246129539)",
+        "id": "commonwealth:3f462x472"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0536, -70.5001, 42.2417, 42.1418)",
+        "id": "commonwealth:3f462w042"
+    },
+    {
+        "bbox": "ENVELOPE(-71.15, -70.83, 42.42, 42.27)",
+        "id": "commonwealth:3f462w07w"
+    },
+    {
+        "bbox": "ENVELOPE(-71.15, -70.83, 42.42, 42.27)",
+        "id": "commonwealth:3f462w05b"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07, -70.85, 42.38, 42.28)",
+        "id": "commonwealth:z603vs146"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07, -70.85, 42.38, 42.28)",
+        "id": "commonwealth:kk91fr068"
+    },
+    {
+        "bbox": "ENVELOPE(-71.49512431024789, -70.99455308992984, 41.90857010739794, 41.369268976662134)",
+        "id": "commonwealth:7h149w07s"
+    },
+    {
+        "bbox": "ENVELOPE(-71.3132, -71.0713, 41.5148, 41.2054)",
+        "id": "commonwealth:7h149z229"
+    },
+    {
+        "bbox": "ENVELOPE(-61.35, -59.34, 47.07, 45.25)",
+        "id": "commonwealth:7h149v78j"
+    },
+    {
+        "bbox": "ENVELOPE(-60.4217, -59.3659, 46.2327, 45.554)",
+        "id": "commonwealth:7h149w014"
+    },
+    {
+        "bbox": "ENVELOPE(-66.383333, -60.783333, 45.95, 43.383333)",
+        "id": "commonwealth:hx11z010p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.8525, -71.521944, 46.706667, 46.6075)",
+        "id": "commonwealth:hx11z058v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.283333, -63.2, 50.566667, 46.75)",
+        "id": "commonwealth:hx11z078b"
+    },
+    {
+        "bbox": "ENVELOPE(-66.383333, -60.85, 46.1, 43.38333)",
+        "id": "commonwealth:hx11z491q"
+    },
+    {
+        "bbox": "ENVELOPE(-60.719444, -59.89111, 46.40166, 45.87583)",
+        "id": "commonwealth:hx11z508p"
+    },
+    {
+        "bbox": "ENVELOPE(-82.11, -79.48, 26.44, 24.24)",
+        "id": "commonwealth:3f462v61g"
+    },
+    {
+        "bbox": "ENVELOPE(-65.01, -63.58, 46.03, 45.29)",
+        "id": "commonwealth:9g54xk65b"
+    },
+    {
+        "bbox": "ENVELOPE(-76.75, -73.8, 40.8, 38.85)",
+        "id": "commonwealth:z603vs71t"
+    },
+    {
+        "bbox": "ENVELOPE(-75.75, -70.75, 46.0, 41.75)",
+        "id": "commonwealth:z603vt56x"
+    },
+    {
+        "bbox": "ENVELOPE(-76.5, -71.75, 45.25, 40.0)",
+        "id": "commonwealth:z603vs06h"
+    },
+    {
+        "bbox": "ENVELOPE(-76.5, -71.75, 45.25, 40.0)",
+        "id": "commonwealth:6t053q283"
+    },
+    {
+        "bbox": "ENVELOPE(-77.85, -61.0, 43.0, 34.85)",
+        "id": "commonwealth:z603vv01j"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -70.0, 35.5, 28.75)",
+        "id": "commonwealth:z603vv02t"
+    },
+    {
+        "bbox": "ENVELOPE(-69.17, -68.02, 44.3, 43.48)",
+        "id": "commonwealth:3f462w131"
+    },
+    {
+        "bbox": "ENVELOPE(-69.17, -68.02, 44.3, 43.48)",
+        "id": "commonwealth:cj82m294c"
+    },
+    {
+        "bbox": "ENVELOPE(-68.0215, -67.0305, 44.4546, 44.2253)",
+        "id": "commonwealth:3f462w37m"
+    },
+    {
+        "bbox": "ENVELOPE(-68.0215, -67.0305, 44.4546, 44.2253)",
+        "id": "commonwealth:3f462w395"
+    },
+    {
+        "bbox": "ENVELOPE(-70.21, -69.17, 44.13, 43.29)",
+        "id": "commonwealth:3f462w15k"
+    },
+    {
+        "bbox": "ENVELOPE(-70.21, -69.17, 44.13, 43.29)",
+        "id": "commonwealth:3f462w27c"
+    },
+    {
+        "bbox": "ENVELOPE(-69.3127, -69.0555, 44.0622, 43.4934)",
+        "id": "commonwealth:3f462w49d"
+    },
+    {
+        "bbox": "ENVELOPE(-69.3127, -69.0555, 44.0622, 43.4934)",
+        "id": "commonwealth:3f462w51f"
+    },
+    {
+        "bbox": "ENVELOPE(-70.1731, -69.4429, 43.5205, 43.3619)",
+        "id": "commonwealth:3f462w29x"
+    },
+    {
+        "bbox": "ENVELOPE(-70.1731, -69.4429, 43.5205, 43.3619)",
+        "id": "commonwealth:3f462w21q"
+    },
+    {
+        "bbox": "ENVELOPE(-69.0624, -68.2954, 44.3105, 44.0827)",
+        "id": "commonwealth:3f462w174"
+    },
+    {
+        "bbox": "ENVELOPE(-69.0624, -68.2954, 44.3105, 44.0827)",
+        "id": "commonwealth:3f462w25t"
+    },
+    {
+        "bbox": "ENVELOPE(-69.1001, -68.2135, 44.3105, 43.5927)",
+        "id": "commonwealth:3f462w238"
+    },
+    {
+        "bbox": "ENVELOPE(-69.1001, -68.2135, 44.3105, 43.5927)",
+        "id": "commonwealth:3f462w19p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.06, -69.56, 42.42, 41.53)",
+        "id": "commonwealth:3f462w31z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.06, -69.56, 42.42, 41.53)",
+        "id": "commonwealth:3f462w33h"
+    },
+    {
+        "bbox": "ENVELOPE(-71.34, -66.57, 44.52, 41.14)",
+        "id": "commonwealth:3f462x63f"
+    },
+    {
+        "bbox": "ENVELOPE(-71.26, -66.25, 45.01, 40.59)",
+        "id": "commonwealth:7h149w057"
+    },
+    {
+        "bbox": "ENVELOPE(-71.34, -66.57, 44.52, 41.14)",
+        "id": "commonwealth:x633fb42w"
+    },
+    {
+        "bbox": "ENVELOPE(-70.56, -70.1, 43.35, 42.44)",
+        "id": "commonwealth:3f462w530"
+    },
+    {
+        "bbox": "ENVELOPE(-70.56, -70.1, 43.35, 42.44)",
+        "id": "commonwealth:3f462w55j"
+    },
+    {
+        "bbox": "ENVELOPE(-71.272, -69.5324, 41.4648, 41.1325)",
+        "id": "commonwealth:7h149x266"
+    },
+    {
+        "bbox": "ENVELOPE(-71.272, -69.5324, 41.4648, 41.1325)",
+        "id": "commonwealth:7h149z36n"
+    },
+    {
+        "bbox": "ENVELOPE(-70.4953, -70.365, 43.0933, 42.5422)",
+        "id": "commonwealth:7h149z86v"
+    },
+    {
+        "bbox": "ENVELOPE(-70.5659, -70.3305, 42.5621, 42.282)",
+        "id": "commonwealth:3f462x650"
+    },
+    {
+        "bbox": "ENVELOPE(-70.5659, -70.3305, 42.5621, 42.282)",
+        "id": "commonwealth:3f462x67j"
+    },
+    {
+        "bbox": "ENVELOPE(-70.0, -46.6, 52.4, 44.4)",
+        "id": "commonwealth:z603vt98f"
+    },
+    {
+        "bbox": "ENVELOPE(-75.0, -49.0, 52.0, 40.0)",
+        "id": "commonwealth:9g54xk56c"
+    },
+    {
+        "bbox": "ENVELOPE(-72.13, -71.15, 41.45, 40.57)",
+        "id": "commonwealth:7h149z13b"
+    },
+    {
+        "bbox": "ENVELOPE(-81.8, -79.81666, 32.85, 29.8)",
+        "id": "commonwealth:hx11z4475"
+    },
+    {
+        "bbox": "ENVELOPE(-81.8, -79.81666, 32.85, 29.8)",
+        "id": "commonwealth:hx11z449q"
+    },
+    {
+        "bbox": "ENVELOPE(-96.0, -61.0, 51.5, 28.75)",
+        "id": "commonwealth:td96p8332"
+    },
+    {
+        "bbox": "ENVELOPE(-82.32, -75.33, 36.58, 33.83)",
+        "id": "commonwealth:z603vs367"
+    },
+    {
+        "bbox": "ENVELOPE(-74.66746876127971, -71.50706413772997, 42.258304064010936, 40.09606406762561)",
+        "id": "commonwealth:z603vt54c"
+    },
+    {
+        "bbox": "ENVELOPE(-74.4, -71.75, 42.0, 40.3)",
+        "id": "commonwealth:z603vt665"
+    },
+    {
+        "bbox": "ENVELOPE(-73.71666, -71.78333, 42.05, 40.98333)",
+        "id": "commonwealth:z603vg132"
+    },
+    {
+        "bbox": "ENVELOPE(-73.71666, -71.78333, 42.05, 40.98333)",
+        "id": "commonwealth:z603vg12s"
+    },
+    {
+        "bbox": "ENVELOPE(-61.0823, -60.5236, 45.3156, 45.2721)",
+        "id": "commonwealth:ws859h140"
+    },
+    {
+        "bbox": "ENVELOPE(-145.0, -73.0, 65.0, 30.0)",
+        "id": "commonwealth:z603vn15n"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -60.0, 30.0, 5.0)",
+        "id": "commonwealth:z603vh20p"
+    },
+    {
+        "bbox": "ENVELOPE(-74.17, -72.42, 42.0, 40.97)",
+        "id": "commonwealth:6t053p82p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.41666, -71.45, 45.0, 42.71666)",
+        "id": "commonwealth:z603vh10f"
+    },
+    {
+        "bbox": "ENVELOPE(-110.0, -50.0, 52.0, 25.0)",
+        "id": "commonwealth:z603vh06v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.5, -71.0, 46.9, 46.6)",
+        "id": "commonwealth:q524n4661"
+    },
+    {
+        "bbox": "ENVELOPE(-72.7, -70.6, 46.71666, 42.65)",
+        "id": "commonwealth:hx11z311k"
+    },
+    {
+        "bbox": "ENVELOPE(-79.75621350941813, -69.82917436831573, 43.56668336055951, 34.73992644519847)",
+        "id": "commonwealth:q524nj17k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.62, -73.18, 41.28, 40.3)",
+        "id": "commonwealth:z603vs260"
+    },
+    {
+        "bbox": "ENVELOPE(-76.5225, -76.2775, 43.481389, 43.198611)",
+        "id": "commonwealth:hx11z1468"
+    },
+    {
+        "bbox": "ENVELOPE(-75.3, -75.1, 39.93, 39.82)",
+        "id": "commonwealth:z603vs12n"
+    },
+    {
+        "bbox": "ENVELOPE(-75.3, -75.1, 39.93, 39.82)",
+        "id": "commonwealth:6w924q14k"
+    },
+    {
+        "bbox": "ENVELOPE(-75.758055, -75.20388, 43.25972, 43.07083)",
+        "id": "commonwealth:hx11z347z"
+    },
+    {
+        "bbox": "ENVELOPE(-73.866667, -73.716667, 41.0, 40.866667)",
+        "id": "commonwealth:p8418t82m"
+    },
+    {
+        "bbox": "ENVELOPE(-61.1633, -61.1238, 45.2134, 45.1956)",
+        "id": "commonwealth:ws859h10w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z535k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z3754"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z373k"
+    },
+    {
+        "bbox": "ENVELOPE(-69.2, -68.6, 12.4, 11.97)",
+        "id": "commonwealth:q524mt87r"
+    },
+    {
+        "bbox": "ENVELOPE(-69.23, -68.7, 12.42, 12.0)",
+        "id": "commonwealth:6t053r56g"
+    },
+    {
+        "bbox": "ENVELOPE(-61.53, -61.2, 15.67, 15.22)",
+        "id": "commonwealth:6t053r289"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.01, 42.39, 42.33)",
+        "id": "commonwealth:dz010v582"
+    },
+    {
+        "bbox": "ENVELOPE(-75.25781957748485, -74.90406888540876, 39.98178877274467, 39.692843859251596)",
+        "id": "commonwealth:q524n9858"
+    },
+    {
+        "bbox": "ENVELOPE(-73.899722, -73.392778, 43.958056, 43.840278)",
+        "id": "commonwealth:hx11z184p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721944, -73.41222, 43.82805, 43.41638)",
+        "id": "commonwealth:hx11z3355"
+    },
+    {
+        "bbox": "ENVELOPE(-84.26, -84.0, 35.64, 35.53)",
+        "id": "commonwealth:q524mt70k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z377p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1356002248019, -71.00600871724747, 42.40493764217304, 42.309703795235954)",
+        "id": "commonwealth:z603vj240"
+    },
+    {
+        "bbox": "ENVELOPE(-71.143611, -71.000278, 42.398611, 42.306944)",
+        "id": "commonwealth:hx11z274n"
+    },
+    {
+        "bbox": "ENVELOPE(-63.0754, -62.5827, 44.4731, 44.4011)",
+        "id": "commonwealth:9g54xm22r"
+    },
+    {
+        "bbox": "ENVELOPE(-63.57, -63.569167, 44.621667, 44.621111)",
+        "id": "commonwealth:6108vv46g"
+    },
+    {
+        "bbox": "ENVELOPE(-52.688889, -52.681111, 47.568611, 47.563056)",
+        "id": "commonwealth:6108vv34p"
+    },
+    {
+        "bbox": "ENVELOPE(-75.332, -74.4139, 40.1311, 39.4204)",
+        "id": "commonwealth:7h149x754"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -69.5, 44.25, 40.5)",
+        "id": "commonwealth:z603vg37n"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -70.0, 44.0, 41.0)",
+        "id": "commonwealth:z603vp64s"
+    },
+    {
+        "bbox": "ENVELOPE(165.0, -25.0, 80.0, 7.0)",
+        "id": "commonwealth:z603vp68w"
+    },
+    {
+        "bbox": "ENVELOPE(-76.583333, -74.483333, 45.066667, 43.4)",
+        "id": "commonwealth:hx11z110w"
+    },
+    {
+        "bbox": "ENVELOPE(-72.0, -64.0, 49.0, 44.0)",
+        "id": "commonwealth:w9505r91w"
+    },
+    {
+        "bbox": "ENVELOPE(-70.1914, -70.1011, 43.4333, 43.3652)",
+        "id": "commonwealth:3f463954x"
+    },
+    {
+        "bbox": "ENVELOPE(-70.1914, -70.1011, 43.4333, 43.3652)",
+        "id": "commonwealth:3f463956g"
+    },
+    {
+        "bbox": "ENVELOPE(-77.1675, -77.165, 40.201389, 40.198611)",
+        "id": "commonwealth:hx11z2413"
+    },
+    {
+        "bbox": "ENVELOPE(-78.281667, -78.263611, 40.0075, 39.996111)",
+        "id": "commonwealth:hx11z247r"
+    },
+    {
+        "bbox": "ENVELOPE(-77.523333, -77.513611, 40.056667, 40.049722)",
+        "id": "commonwealth:hx11z243n"
+    },
+    {
+        "bbox": "ENVELOPE(-76.809166, -76.77666, 40.88972, 40.86361)",
+        "id": "commonwealth:hx11z3975"
+    },
+    {
+        "bbox": "ENVELOPE(-78.505556, -78.502778, 40.020556, 40.018889)",
+        "id": "commonwealth:6108vv62v"
+    },
+    {
+        "bbox": "ENVELOPE(-78.505556, -78.502778, 40.020556, 40.018889)",
+        "id": "commonwealth:hx11z215g"
+    },
+    {
+        "bbox": "ENVELOPE(-78.506666, -78.50194, 40.02111, 40.01833)",
+        "id": "commonwealth:hx11z401j"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5925, -73.5775, 43.27, 43.25583)",
+        "id": "commonwealth:hx11z525b"
+    },
+    {
+        "bbox": "ENVELOPE(-77.961389, -77.952222, 40.0675, 40.060278)",
+        "id": "commonwealth:hx11z2456"
+    },
+    {
+        "bbox": "ENVELOPE(-80.010278, -80.006944, 40.440556, 40.438611)",
+        "id": "commonwealth:hx11xz64m"
+    },
+    {
+        "bbox": "ENVELOPE(-63.3048, -61.5207, 45.5419, 45.3653)",
+        "id": "commonwealth:ws859h30c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.8, -73.06666, 46.06666, 43.26666)",
+        "id": "commonwealth:hx11z328r"
+    },
+    {
+        "bbox": "ENVELOPE(-76.531389, -76.486667, 37.253889, 37.22)",
+        "id": "commonwealth:hx11z255f"
+    },
+    {
+        "bbox": "ENVELOPE(-145.0, -20.0, 75.0, -5.0)",
+        "id": "commonwealth:z603vr80k"
+    },
+    {
+        "bbox": "ENVELOPE(-145.0, -20.0, 75.0, -5.0)",
+        "id": "commonwealth:9s161g59k"
+    },
+    {
+        "bbox": "ENVELOPE(-89.0, -71.0, 46.0, 36.0)",
+        "id": "commonwealth:9s161b92s"
+    },
+    {
+        "bbox": "ENVELOPE(-89.0, -71.0, 46.0, 36.0)",
+        "id": "commonwealth:q524mt73d"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -45.0, 55.0, 39.0)",
+        "id": "commonwealth:cj82m113z"
+    },
+    {
+        "bbox": "ENVELOPE(-94.0, -73.0, 37.0, 24.0)",
+        "id": "commonwealth:9s161c45m"
+    },
+    {
+        "bbox": "ENVELOPE(-90.76666, -80.83333, 35.0, 30.18333)",
+        "id": "commonwealth:z603vg21r"
+    },
+    {
+        "bbox": "ENVELOPE(-69.6, -68.233333, 47.866667, 47.333333)",
+        "id": "commonwealth:hx11z080c"
+    },
+    {
+        "bbox": "ENVELOPE(-61.81, -61.58, 12.24, 11.98)",
+        "id": "commonwealth:q524mt970"
+    },
+    {
+        "bbox": "ENVELOPE(-73.98, -73.9, 40.89, 40.79)",
+        "id": "commonwealth:z603vv86v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.09, -71.04, 42.38, 42.34)",
+        "id": "commonwealth:4m90fp50w"
+    },
+    {
+        "bbox": "ENVELOPE(-62.0, -60.92, 16.57, 15.77)",
+        "id": "commonwealth:6t053r54x"
+    },
+    {
+        "bbox": "ENVELOPE(-61.2948, -61.0816, 45.4219, 45.2919)",
+        "id": "commonwealth:ws859h183"
+    },
+    {
+        "bbox": "ENVELOPE(-63.41, -63.2605, 44.4413, 44.34)",
+        "id": "commonwealth:9g54xm206"
+    },
+    {
+        "bbox": "ENVELOPE(-63.41, -63.2605, 44.4413, 44.34)",
+        "id": "commonwealth:9g54xm185"
+    },
+    {
+        "bbox": "ENVELOPE(-63.595, -63.558889, 44.654722, 44.616944)",
+        "id": "commonwealth:hx11z036t"
+    },
+    {
+        "bbox": "ENVELOPE(-64.36, -64.06, 49.0, 48.25)",
+        "id": "commonwealth:7h149v54z"
+    },
+    {
+        "bbox": "ENVELOPE(-64.5646, -64.354, 46.4425, 46.2404)",
+        "id": "commonwealth:7h149v69k"
+    },
+    {
+        "bbox": "ENVELOPE(-83.45, -4.07, 52.01, 23.3)",
+        "id": "commonwealth:3f462v57w"
+    },
+    {
+        "bbox": "ENVELOPE(-79.9575, -79.92194, 32.79138, 32.76805)",
+        "id": "commonwealth:hx11z451r"
+    },
+    {
+        "bbox": "ENVELOPE(-70.529167, -70.256944, 47.468056, 47.339167)",
+        "id": "commonwealth:hx11z0640"
+    },
+    {
+        "bbox": "ENVELOPE(-62.87, -62.62, 17.42, 17.21)",
+        "id": "commonwealth:q524mv01c"
+    },
+    {
+        "bbox": "ENVELOPE(-61.29, -61.1, 13.39, 13.11)",
+        "id": "commonwealth:q524mt95f"
+    },
+    {
+        "bbox": "ENVELOPE(-71.3, -71.02, 21.54, 21.17)",
+        "id": "commonwealth:q524mt899"
+    },
+    {
+        "bbox": "ENVELOPE(-76.85, -75.0, 40.4, 39.25)",
+        "id": "commonwealth:z603vt134"
+    },
+    {
+        "bbox": "ENVELOPE(-65.01, -63.53, 46.03, 44.56)",
+        "id": "commonwealth:9g54xk63s"
+    },
+    {
+        "bbox": "ENVELOPE(-78.5769149122525, -76.01072095574727, 18.85570109113877, 16.921081018275203)",
+        "id": "commonwealth:x633f9005"
+    },
+    {
+        "bbox": "ENVELOPE(-78.67, -76.18, 18.56, 17.6)",
+        "id": "commonwealth:q524mt83n"
+    },
+    {
+        "bbox": "ENVELOPE(-75.0, -61.0, 48.0, 42.0)",
+        "id": "commonwealth:z603vr38k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.04, -73.43, 45.73, 45.28)",
+        "id": "commonwealth:z603vv76m"
+    },
+    {
+        "bbox": "ENVELOPE(-79.0, -67.0, 45.0, 39.0)",
+        "id": "commonwealth:z603vv806"
+    },
+    {
+        "bbox": "ENVELOPE(-62.5204, -62.3727, 44.4858, 44.4151)",
+        "id": "commonwealth:9g54xm26v"
+    },
+    {
+        "bbox": "ENVELOPE(-64.2233, -64.0337, 44.2829, 44.1543)",
+        "id": "commonwealth:9g54xk94s"
+    },
+    {
+        "bbox": "ENVELOPE(-76.35, -70.35, 44.0, 38.9)",
+        "id": "commonwealth:z603vv46w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721944, -73.41222, 43.82805, 43.41638)",
+        "id": "commonwealth:hx11z333m"
+    },
+    {
+        "bbox": "ENVELOPE(-79.883333, -76.0, 44.35, 43.1)",
+        "id": "commonwealth:hx11xz56x"
+    },
+    {
+        "bbox": "ENVELOPE(-79.966667, -73.8, 45.5, 43.083333)",
+        "id": "commonwealth:hx11z134g"
+    },
+    {
+        "bbox": "ENVELOPE(-79.966667, -73.8, 45.5, 43.083333)",
+        "id": "commonwealth:hx11z1361"
+    },
+    {
+        "bbox": "ENVELOPE(-79.966667, -73.8, 45.5, 43.083333)",
+        "id": "commonwealth:hx11z138k"
+    },
+    {
+        "bbox": "ENVELOPE(-140.0, -5.0, 55.0, -60.0)",
+        "id": "commonwealth:z603vt92s"
+    },
+    {
+        "bbox": "ENVELOPE(-65.1, -63.6, 46.0, 45.15)",
+        "id": "commonwealth:z603vr96g"
+    },
+    {
+        "bbox": "ENVELOPE(-65.1, -63.6, 46.0, 45.15)",
+        "id": "commonwealth:q524mv32c"
+    },
+    {
+        "bbox": "ENVELOPE(-65.1, -63.6, 46.0, 45.15)",
+        "id": "commonwealth:6t053n859"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -72.0, 48.0, 43.0)",
+        "id": "commonwealth:z603vr34g"
+    },
+    {
+        "bbox": "ENVELOPE(-63.5658, -63.3206, 44.3405, 44.2516)",
+        "id": "commonwealth:9g54xm10z"
+    },
+    {
+        "bbox": "ENVELOPE(-61.2049, -60.3938, 45.394, 45.2721)",
+        "id": "commonwealth:ws859h16j"
+    },
+    {
+        "bbox": "ENVELOPE(-64.4403, -64.3704, 44.033, 43.5939)",
+        "id": "commonwealth:9g54xk90p"
+    },
+    {
+        "bbox": "ENVELOPE(-62.13, -61.13, 47.51, 47.08)",
+        "id": "commonwealth:7h149v735"
+    },
+    {
+        "bbox": "ENVELOPE(-81.415, -81.40666, 31.1225, 31.11777)",
+        "id": "commonwealth:hx11z457d"
+    },
+    {
+        "bbox": "ENVELOPE(-79.5, -69.5, 45.0, 36.5)",
+        "id": "commonwealth:4t64hr28s"
+    },
+    {
+        "bbox": "ENVELOPE(-71.075, -71.05, 42.37, 42.345)",
+        "id": "commonwealth:z603vw16c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.83333, -71.16666, 42.16666, 40.66666)",
+        "id": "commonwealth:z603vg14b"
+    },
+    {
+        "bbox": "ENVELOPE(-94.0, -77.0, 34.0, 21.0)",
+        "id": "commonwealth:z603vr361"
+    },
+    {
+        "bbox": "ENVELOPE(-73.388889, -73.386111, 43.8425, 43.840556)",
+        "id": "commonwealth:hx11z178j"
+    },
+    {
+        "bbox": "ENVELOPE(-83.533333, -82.733333, 42.433333, 41.383333)",
+        "id": "commonwealth:hx11xz622"
+    },
+    {
+        "bbox": "ENVELOPE(-80.01, -80.006944, 40.4425, 40.439167)",
+        "id": "commonwealth:hx11z2235"
+    },
+    {
+        "bbox": "ENVELOPE(-79.86666, -76.26666, 43.41666, 41.88333)",
+        "id": "commonwealth:z603vg663"
+    },
+    {
+        "bbox": "ENVELOPE(-73.51, -69.92, 42.89, 41.23)",
+        "id": "commonwealth:j3860855n"
+    },
+    {
+        "bbox": "ENVELOPE(-73.93902120304712, -69.60377996037693, 43.173682894025404, 41.03655693549046)",
+        "id": "commonwealth:j38608533"
+    },
+    {
+        "bbox": "ENVELOPE(-71.498056, -71.076389, 41.851111, 41.4375)",
+        "id": "commonwealth:hx11z278r"
+    },
+    {
+        "bbox": "ENVELOPE(-72.766667, -70.516667, 42.866667, 41.783333)",
+        "id": "commonwealth:hx11z569d"
+    },
+    {
+        "bbox": "ENVELOPE(-81.58333, -69.58333, 48.0, 38.0)",
+        "id": "commonwealth:z603vg38x"
+    },
+    {
+        "bbox": "ENVELOPE(-74.275277, -73.71833, 40.86277, 40.49361)",
+        "id": "commonwealth:hx11z3576"
+    },
+    {
+        "bbox": "ENVELOPE(-74.32, -73.47, 40.75, 40.3)",
+        "id": "commonwealth:z603vq27v"
+    },
+    {
+        "bbox": "ENVELOPE(-79.085833, -78.868056, 43.289444, 42.862778)",
+        "id": "commonwealth:hx11z116j"
+    },
+    {
+        "bbox": "ENVELOPE(177.13333, -46.56666, 72.21666, 5.55)",
+        "id": "commonwealth:z603vg506"
+    },
+    {
+        "bbox": "ENVELOPE(-66.58, -58.33, 47.42, 43.42)",
+        "id": "commonwealth:z603vt355"
+    },
+    {
+        "bbox": "ENVELOPE(-66.75, -59.25, 47.25, 43.25)",
+        "id": "commonwealth:td96p834b"
+    },
+    {
+        "bbox": "ENVELOPE(-126.14273503973286, -71.95862519992059, 54.33382911505197, 32.771432747638755)",
+        "id": "commonwealth:4t64hr23d"
+    },
+    {
+        "bbox": "ENVELOPE(-77.25, -74.71666, 41.31666, 39.93333)",
+        "id": "commonwealth:z603vg73h"
+    },
+    {
+        "bbox": "ENVELOPE(-71.355278, -71.174167, 46.828889, 46.733889)",
+        "id": "commonwealth:hx11xz60h"
+    },
+    {
+        "bbox": "ENVELOPE(-81.4475, -81.26583, 31.35083, 31.00694)",
+        "id": "commonwealth:hx11z4539"
+    },
+    {
+        "bbox": "ENVELOPE(-81.4475, -81.26583, 31.35083, 31.00694)",
+        "id": "commonwealth:hx11z455v"
+    },
+    {
+        "bbox": "ENVELOPE(-90.0, -77.0, 34.67, 30.83)",
+        "id": "commonwealth:z603vs34p"
+    },
+    {
+        "bbox": "ENVELOPE(-81.0, -76.9, 34.65, 30.85)",
+        "id": "commonwealth:0r96fq92k"
+    },
+    {
+        "bbox": "ENVELOPE(-104.0, -76.0, 46.0, 28.0)",
+        "id": "commonwealth:z603vq84g"
+    },
+    {
+        "bbox": "ENVELOPE(-104.0, -76.0, 46.0, 28.0)",
+        "id": "commonwealth:z603vp20q"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -78.0, 41.0, 38.0)",
+        "id": "commonwealth:z603vr30c"
+    },
+    {
+        "bbox": "ENVELOPE(-107.0, -52.0, 52.0, 28.0)",
+        "id": "commonwealth:4t64hr30t"
+    },
+    {
+        "bbox": "ENVELOPE(-101.0, -52.0, 73.0, 28.0)",
+        "id": "commonwealth:p8418t45g"
+    },
+    {
+        "bbox": "ENVELOPE(-106.0, -52.0, 52.0, 28.0)",
+        "id": "commonwealth:z603vt33m"
+    },
+    {
+        "bbox": "ENVELOPE(-106.0, -52.0, 52.0, 28.0)",
+        "id": "commonwealth:hq37vw00x"
+    },
+    {
+        "bbox": "ENVELOPE(-101.0, -56.0, 41.0, 29.0)",
+        "id": "commonwealth:z603vp342"
+    },
+    {
+        "bbox": "ENVELOPE(-100.0, -51.0, 53.0, 28.0)",
+        "id": "commonwealth:z603vp76k"
+    },
+    {
+        "bbox": "ENVELOPE(-100.0, -51.0, 53.0, 28.0)",
+        "id": "commonwealth:z603vp30z"
+    },
+    {
+        "bbox": "ENVELOPE(-99.2, -52.01666, 52.96666, 28.28333)",
+        "id": "commonwealth:hx11z549x"
+    },
+    {
+        "bbox": "ENVELOPE(-81.500555, -81.01138, 30.45555, 29.25111)",
+        "id": "commonwealth:hx11z473s"
+    },
+    {
+        "bbox": "ENVELOPE(-81.500555, -81.01138, 30.45555, 29.25111)",
+        "id": "commonwealth:hx11z475b"
+    },
+    {
+        "bbox": "ENVELOPE(-73.66666, -60.66666, 47.0, 39.0)",
+        "id": "commonwealth:z603vg417"
+    },
+    {
+        "bbox": "ENVELOPE(-73.75, -71.12, 42.0, 41.0)",
+        "id": "commonwealth:8049g9651"
+    },
+    {
+        "bbox": "ENVELOPE(-72.83, -69.83, 42.42, 40.75)",
+        "id": "commonwealth:6t053p17c"
+    },
+    {
+        "bbox": "ENVELOPE(-71.839444, -71.345833, 42.113611, 41.873889)",
+        "id": "commonwealth:hx11xz398"
+    },
+    {
+        "bbox": "ENVELOPE(-80.2, -78.6, 40.85, 38.9)",
+        "id": "commonwealth:q524mv470"
+    },
+    {
+        "bbox": "ENVELOPE(-80.2, -78.6, 40.85, 38.9)",
+        "id": "commonwealth:cj82m572z"
+    },
+    {
+        "bbox": "ENVELOPE(-76.08498994821413, -73.94721494943656, 40.596402528148296, 39.498426056732605)",
+        "id": "commonwealth:z603vp784"
+    },
+    {
+        "bbox": "ENVELOPE(-83.75, -78.5, 41.75, 39.25)",
+        "id": "commonwealth:q524n480v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08333, -66.93333, 47.45, 42.96666)",
+        "id": "commonwealth:z603vg28p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.355278, -71.238611, 46.8075, 46.745278)",
+        "id": "commonwealth:hx11xz68q"
+    },
+    {
+        "bbox": "ENVELOPE(-133.92760131714584, 42.557923150137555, 51.38913660325958, -64.8679101470876)",
+        "id": "commonwealth:z603vg905"
+    },
+    {
+        "bbox": "ENVELOPE(-77.83, -69.5, 48.0, 43.5)",
+        "id": "commonwealth:q524mv071"
+    },
+    {
+        "bbox": "ENVELOPE(-77.83, -69.5, 48.0, 43.5)",
+        "id": "commonwealth:cj82m245f"
+    },
+    {
+        "bbox": "ENVELOPE(-75.67, -69.33, 20.67, 17.33)",
+        "id": "commonwealth:6t053r44p"
+    },
+    {
+        "bbox": "ENVELOPE(-84.54, -65.39, 47.35, 36.07)",
+        "id": "commonwealth:cj82m2356"
+    },
+    {
+        "bbox": "ENVELOPE(-84.03, -66.33, 45.5, 36.41)",
+        "id": "commonwealth:cj82m310j"
+    },
+    {
+        "bbox": "ENVELOPE(-87.0515326093821, -71.46923091778274, 46.50719554800079, 37.61043569385761)",
+        "id": "commonwealth:9s161c076"
+    },
+    {
+        "bbox": "ENVELOPE(-74.54810405354007, -69.26373840778885, 43.69323004966309, 39.99217462625201)",
+        "id": "commonwealth:z603vr53p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:3f462v77c"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:3f462v79x"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:3f462v81z"
+    },
+    {
+        "bbox": "ENVELOPE(-74.44339701987136, -68.89051908205163, 44.61819581126622, 40.18272101978786)",
+        "id": "commonwealth:cj82kn152"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:cj82kn17m"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:x633fb36r"
+    },
+    {
+        "bbox": "ENVELOPE(-71.25, -68.9, 44.5, 40.5)",
+        "id": "commonwealth:0r96fq69s"
+    },
+    {
+        "bbox": "ENVELOPE(-82.69055917287892, -73.23744389426906, 41.213943812058446, 35.359178236841)",
+        "id": "commonwealth:z603vr10w"
+    },
+    {
+        "bbox": "ENVELOPE(-82.25, -74.0, 40.25, 35.75)",
+        "id": "commonwealth:q524mt68j"
+    },
+    {
+        "bbox": "ENVELOPE(-82.25, -74.0, 40.25, 35.75)",
+        "id": "commonwealth:0r96fq87q"
+    },
+    {
+        "bbox": "ENVELOPE(-91.0, -78.0, 32.0, 23.0)",
+        "id": "commonwealth:z603vg16w"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -78.0, 49.0, 36.0)",
+        "id": "commonwealth:z603vt622"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -67.0, 46.0, 41.0)",
+        "id": "commonwealth:j3860823c"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -67.0, 46.0, 41.0)",
+        "id": "commonwealth:9s161c11s"
+    },
+    {
+        "bbox": "ENVELOPE(-95.0, -67.0, 46.0, 37.0)",
+        "id": "commonwealth:z603vq88k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.283, -73.07, 41.07, 40.5)",
+        "id": "commonwealth:z603vq32q"
+    },
+    {
+        "bbox": "ENVELOPE(-81.397777, -81.38527, 31.1375, 31.1325)",
+        "id": "commonwealth:hx11z467n"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -70.0, 43.0, 41.0)",
+        "id": "commonwealth:j3860825x"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -70.0, 43.0, 41.0)",
+        "id": "commonwealth:x059cd46p"
+    },
+    {
+        "bbox": "ENVELOPE(-76.733333, -71.966667, 45.8, 40.45)",
+        "id": "commonwealth:hx11z2057"
+    },
+    {
+        "bbox": "ENVELOPE(-72.45, -70.45, 45.55, 38.7)",
+        "id": "commonwealth:z603vs634"
+    },
+    {
+        "bbox": "ENVELOPE(-76.583333, -71.85, 45.61666, 40.48333)",
+        "id": "commonwealth:hx11z315p"
+    },
+    {
+        "bbox": "ENVELOPE(-76.583333, -71.85, 45.61666, 40.48333)",
+        "id": "commonwealth:hx11z3177"
+    },
+    {
+        "bbox": "ENVELOPE(-91.0, -85.0, 31.33333, 27.5)",
+        "id": "commonwealth:z603vg20g"
+    },
+    {
+        "bbox": "ENVELOPE(-91.0, -85.0, 31.0, 28.0)",
+        "id": "commonwealth:6t053p669"
+    },
+    {
+        "bbox": "ENVELOPE(-71.386944, -70.808333, 42.928611, 42.633611)",
+        "id": "commonwealth:hx11z5730"
+    },
+    {
+        "bbox": "ENVELOPE(-74.033333, -66.2, 45.3, 40.533333)",
+        "id": "commonwealth:hx11z5595"
+    },
+    {
+        "bbox": "ENVELOPE(-71.45, -70.8, 42.5, 42.16666)",
+        "id": "commonwealth:z603vg83r"
+    },
+    {
+        "bbox": "ENVELOPE(-72.6, -70.05, 47.7, 46.3)",
+        "id": "commonwealth:q524n470m"
+    },
+    {
+        "bbox": "ENVELOPE(-91.0, -75.0, 39.0, 31.0)",
+        "id": "commonwealth:9s161c09r"
+    },
+    {
+        "bbox": "ENVELOPE(-80.51666, -74.68333, 42.26666, 39.71666)",
+        "id": "commonwealth:z603vg727"
+    },
+    {
+        "bbox": "ENVELOPE(-71.88, -71.1, 42.03, 41.21)",
+        "id": "commonwealth:js956k034"
+    },
+    {
+        "bbox": "ENVELOPE(-73.41666, -71.45, 45.0, 42.71666)",
+        "id": "commonwealth:z603vh11q"
+    },
+    {
+        "bbox": "ENVELOPE(-73.51666, -70.53333, 45.3, 42.68333)",
+        "id": "commonwealth:z603vg45b"
+    },
+    {
+        "bbox": "ENVELOPE(-65.016666, -63.41666, 46.11666, 44.41666)",
+        "id": "commonwealth:hx11z499x"
+    },
+    {
+        "bbox": "ENVELOPE(-95.0, -52.0, 52.0, 30.0)",
+        "id": "commonwealth:2801sp51b"
+    },
+    {
+        "bbox": "ENVELOPE(-97.0, -69.0, 50.0, 30.0)",
+        "id": "commonwealth:z603vt312"
+    },
+    {
+        "bbox": "ENVELOPE(-98.5, -69.17, 50.5, 24.5)",
+        "id": "commonwealth:z603vq968"
+    },
+    {
+        "bbox": "ENVELOPE(-100.86423604161571, -63.82482510748221, 49.24416494458589, 28.366473199073496)",
+        "id": "commonwealth:8049g933r"
+    },
+    {
+        "bbox": "ENVELOPE(-65.0, -57.0, 45.0, 36.0)",
+        "id": "commonwealth:z603vm73b"
+    },
+    {
+        "bbox": "ENVELOPE(-92.58, -74.58, 45.0, 36.0)",
+        "id": "commonwealth:q524mt71v"
+    },
+    {
+        "bbox": "ENVELOPE(-94.05, -75.76666, 46.31666, 36.01666)",
+        "id": "commonwealth:hx11z4254"
+    },
+    {
+        "bbox": "ENVELOPE(-85.1, -79.533333, 37.85, 35.366667)",
+        "id": "commonwealth:hx11z284w"
+    },
+    {
+        "bbox": "ENVELOPE(-95.016667, -85.983333, 35.683333, 28.916667)",
+        "id": "commonwealth:hx11z2880"
+    },
+    {
+        "bbox": "ENVELOPE(-125.30100639298574, -55.988542138089315, 38.85925539967021, 3.1499120332645845)",
+        "id": "commonwealth:q524nk81t"
+    },
+    {
+        "bbox": "ENVELOPE(-80.013333, -80.000278, 40.444722, 40.436389)",
+        "id": "commonwealth:hx11z221m"
+    },
+    {
+        "bbox": "ENVELOPE(-73.716667, -71.466667, 43.95, 41.766667)",
+        "id": "commonwealth:hx11z172w"
+    },
+    {
+        "bbox": "ENVELOPE(-95.3, -83.983333, 49.1, 41.083333)",
+        "id": "commonwealth:hx11z2987"
+    },
+    {
+        "bbox": "ENVELOPE(-95.3, -83.983333, 49.1, 41.083333)",
+        "id": "commonwealth:6108vw16z"
+    },
+    {
+        "bbox": "ENVELOPE(-80.416667, -78.55, 42.316667, 39.583333)",
+        "id": "commonwealth:hx11z235z"
+    },
+    {
+        "bbox": "ENVELOPE(-80.416667, -78.55, 42.316667, 39.583333)",
+        "id": "commonwealth:hx11z231v"
+    },
+    {
+        "bbox": "ENVELOPE(-66.183333, -63.716667, 46.233333, 45.183333)",
+        "id": "commonwealth:hx11z0348"
+    },
+    {
+        "bbox": "ENVELOPE(-75.474722, -75.007778, 40.020556, 39.776667)",
+        "id": "commonwealth:6108vv609"
+    },
+    {
+        "bbox": "ENVELOPE(-80.35, -70.833333, 44.233333, 39.066667)",
+        "id": "commonwealth:hx11z162n"
+    },
+    {
+        "bbox": "ENVELOPE(-52.720278, -52.664167, 47.586389, 47.559722)",
+        "id": "commonwealth:6108vv12n"
+    },
+    {
+        "bbox": "ENVELOPE(-52.720278, -52.664167, 47.586389, 47.559722)",
+        "id": "commonwealth:6108vv260"
+    },
+    {
+        "bbox": "ENVELOPE(-71.088056, -70.960278, 42.389722, 42.329722)",
+        "id": "commonwealth:hx11xz508"
+    },
+    {
+        "bbox": "ENVELOPE(-75.511667, -75.488611, 44.704167, 44.6875)",
+        "id": "commonwealth:hx11z098t"
+    },
+    {
+        "bbox": "ENVELOPE(-75.65, -74.68333, 40.41666, 39.65)",
+        "id": "commonwealth:hx11z395m"
+    },
+    {
+        "bbox": "ENVELOPE(-90.0, -52.0, 52.0, 31.0)",
+        "id": "commonwealth:z603vp18p"
+    },
+    {
+        "bbox": "ENVELOPE(-77.733333, -74.983333, 38.65, 36.7)",
+        "id": "commonwealth:hx11z253w"
+    },
+    {
+        "bbox": "ENVELOPE(-82.5, -74.5, 40.5, 31.7)",
+        "id": "commonwealth:9s1618671"
+    },
+    {
+        "bbox": "ENVELOPE(-61.25, -60.78, 14.89, 14.35)",
+        "id": "commonwealth:q524n542n"
+    },
+    {
+        "bbox": "ENVELOPE(-74.42872635689552, -69.76340844624534, 43.05473407795924, 40.87211198228137)",
+        "id": "commonwealth:wd376570r"
+    },
+    {
+        "bbox": "ENVELOPE(-75.07674099646984, -69.00495304701046, 44.093564030236486, 40.646481833493695)",
+        "id": "commonwealth:j3860865w"
+    },
+    {
+        "bbox": "ENVELOPE(-69.298055, -68.73583, 44.57555, 43.90138)",
+        "id": "commonwealth:hx11z3070"
+    },
+    {
+        "bbox": "ENVELOPE(-64.2303, -64.0434, 44.35, 44.2608)",
+        "id": "commonwealth:9g54xk96b"
+    },
+    {
+        "bbox": "ENVELOPE(-61.3152, -61.2824, 45.2709, 45.2252)",
+        "id": "commonwealth:ws859h12f"
+    },
+    {
+        "bbox": "ENVELOPE(-65.3951, -64.4635, 47.1212, 46.5443)",
+        "id": "commonwealth:7h149v646"
+    },
+    {
+        "bbox": "ENVELOPE(-91.44, -90.48, 32.56, 30.17)",
+        "id": "commonwealth:7h149x83t"
+    },
+    {
+        "bbox": "ENVELOPE(-68.3338, -68.0403, 44.3019, 44.0549)",
+        "id": "commonwealth:3f462w459"
+    },
+    {
+        "bbox": "ENVELOPE(-68.3338, -68.0403, 44.3019, 44.0549)",
+        "id": "commonwealth:3f462w47v"
+    },
+    {
+        "bbox": "ENVELOPE(160.0, -10.0, 80.0, 10.0)",
+        "id": "commonwealth:z603vq10p"
+    },
+    {
+        "bbox": "ENVELOPE(-71.464722, -71.173055, 41.769444, 41.441111)",
+        "id": "commonwealth:hx11z259j"
+    },
+    {
+        "bbox": "ENVELOPE(-71.464722, -71.173055, 41.769444, 41.441111)",
+        "id": "commonwealth:hx11z2570"
+    },
+    {
+        "bbox": "ENVELOPE(-6.35, -3.45, 38.0, 35.0)",
+        "id": "commonwealth:z603vt800"
+    },
+    {
+        "bbox": "ENVELOPE(-111.0, -69.0, 49.0, 25.0)",
+        "id": "commonwealth:z603vg264"
+    },
+    {
+        "bbox": "ENVELOPE(140.0, -0.0, 80.0, 0.0)",
+        "id": "commonwealth:z603vp164"
+    },
+    {
+        "bbox": "ENVELOPE(-101.15120700645454, -52.012824099348286, 32.994950400910085, 2.4744583320175018)",
+        "id": "commonwealth:6t053r92b"
+    },
+    {
+        "bbox": "ENVELOPE(-77.67, -74.0, 40.25, 36.6)",
+        "id": "commonwealth:3f462z14q"
+    },
+    {
+        "bbox": "ENVELOPE(-77.65, -74.0, 40.25, 36.55)",
+        "id": "commonwealth:3f462z39k"
+    },
+    {
+        "bbox": "ENVELOPE(-108.63500817839608, -46.11167804536141, 42.87101935509957, -3.5297341317531306)",
+        "id": "commonwealth:x633f8459"
+    },
+    {
+        "bbox": "ENVELOPE(-91.0, -80.0, 31.0, 24.0)",
+        "id": "commonwealth:6t053p70w"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -74.0, 41.0, 39.0)",
+        "id": "commonwealth:z603vq241"
+    },
+    {
+        "bbox": "ENVELOPE(-98.0, -50.0, 55.0, 28.0)",
+        "id": "commonwealth:z603vp51q"
+    },
+    {
+        "bbox": "ENVELOPE(-80.5, -77.66666, 33.83333, 32.0)",
+        "id": "commonwealth:z603vg91f"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5, -70.0, 43.0, 41.0)",
+        "id": "commonwealth:j3860819s"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5, -70.0, 43.0, 41.0)",
+        "id": "commonwealth:wd3765665"
+    },
+    {
+        "bbox": "ENVELOPE(-91.5, -50.6, 52.4, 28.3)",
+        "id": "commonwealth:z603vs46g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.25, -70.0, 43.0, 41.25)",
+        "id": "commonwealth:hq37vv48w"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0, -68.0, 47.0, 43.0)",
+        "id": "commonwealth:8049g963g"
+    },
+    {
+        "bbox": "ENVELOPE(-85.0, -82.0, 35.0, 31.0)",
+        "id": "commonwealth:6t053p68v"
+    },
+    {
+        "bbox": "ENVELOPE(-76.0, -74.0, 41.0, 40.0)",
+        "id": "commonwealth:6t053q347"
+    },
+    {
+        "bbox": "ENVELOPE(-81.83, -78.83, 35.13, 31.83)",
+        "id": "commonwealth:6w924q10g"
+    },
+    {
+        "bbox": "ENVELOPE(-116.70412221644261, -54.00723409872387, 35.6254005905777, -3.625821804005298)",
+        "id": "commonwealth:x633f846k"
+    },
+    {
+        "bbox": "ENVELOPE(-85.85, -70.0, 30.75, 23.2)",
+        "id": "commonwealth:z603vv04c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.85945398289378, -71.53242287625129, 42.17335683414941, 40.729938360929815)",
+        "id": "commonwealth:z603vg15m"
+    },
+    {
+        "bbox": "ENVELOPE(-99.0, -51.0, 53.0, 28.0)",
+        "id": "commonwealth:z603vp848"
+    },
+    {
+        "bbox": "ENVELOPE(-99.0, -51.0, 53.0, 28.0)",
+        "id": "commonwealth:z603vp86t"
+    },
+    {
+        "bbox": "ENVELOPE(-118.0, -47.0, 55.0, 4.0)",
+        "id": "commonwealth:z603vr867"
+    },
+    {
+        "bbox": "ENVELOPE(-118.0, -47.0, 55.0, 4.0)",
+        "id": "commonwealth:w9505r594"
+    },
+    {
+        "bbox": "ENVELOPE(-131.01157669004135, -32.72444530910427, 55.31766033545884, -1.4538670507473626)",
+        "id": "commonwealth:z603vp805"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -40.0, 33.0, 4.0)",
+        "id": "commonwealth:z603vh316"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -44.0, 54.0, 39.0)",
+        "id": "commonwealth:x059cd380"
+    },
+    {
+        "bbox": "ENVELOPE(-28.606058089107258, 59.33051230738145, 48.657573978422306, -14.834378365139528)",
+        "id": "commonwealth:3f462v55b"
+    },
+    {
+        "bbox": "ENVELOPE(-78.15, -77.85, 34.05, 33.8)",
+        "id": "commonwealth:q524n484z"
+    },
+    {
+        "bbox": "ENVELOPE(-86.65076179959219, -68.54004841086297, 47.119498230836406, 35.339790444893474)",
+        "id": "commonwealth:x059cd355"
+    },
+    {
+        "bbox": "ENVELOPE(-94.0, -74.0, 36.5, 24.0)",
+        "id": "commonwealth:x059cd32b"
+    },
+    {
+        "bbox": "ENVELOPE(-78.0, -68.0, 45.0, 36.0)",
+        "id": "commonwealth:3f462z592"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0, -56.0, 47.0, 42.0)",
+        "id": "commonwealth:kk91fq64z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0, -55.5, 47.35, 41.5)",
+        "id": "commonwealth:z603vt99q"
+    },
+    {
+        "bbox": "ENVELOPE(-78.0, -72.5, 41.0, 34.58)",
+        "id": "commonwealth:z603vq127"
+    },
+    {
+        "bbox": "ENVELOPE(-58.4, -52.7, 8.0, 3.0)",
+        "id": "commonwealth:3f462z11w"
+    },
+    {
+        "bbox": "ENVELOPE(-89.0, -72.0, 27.0, 16.0)",
+        "id": "commonwealth:6t053q62d"
+    },
+    {
+        "bbox": "ENVELOPE(-83.0, 5.0, 53.0, 5.0)",
+        "id": "commonwealth:z603vm55d"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, 10.0, 52.0, 0.0)",
+        "id": "commonwealth:3f462v59f"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -50.0, 35.0, 0.0)",
+        "id": "commonwealth:q524n495g"
+    },
+    {
+        "bbox": "ENVELOPE(-98.5, -58.0, 31.5, 6.0)",
+        "id": "commonwealth:3f462z435"
+    },
+    {
+        "bbox": "ENVELOPE(-98.5, -58.0, 31.5, 6.0)",
+        "id": "commonwealth:3f462z41m"
+    },
+    {
+        "bbox": "ENVELOPE(-72.41666, -70.5, 44.83333, 42.58333)",
+        "id": "commonwealth:z603vg46m"
+    },
+    {
+        "bbox": "ENVELOPE(-72.55, -70.55, 44.76, 42.55)",
+        "id": "commonwealth:7d27c951g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.33333, -68.16666, 46.66666, 42.5)",
+        "id": "commonwealth:z603vg42h"
+    },
+    {
+        "bbox": "ENVELOPE(170.0, -3.0, 80.0, 4.0)",
+        "id": "commonwealth:4m90fp515"
+    },
+    {
+        "bbox": "ENVELOPE(-118.0, -45.0, 55.0, 5.0)",
+        "id": "commonwealth:z603vt37q"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -58.5, 50.5, 42.5)",
+        "id": "commonwealth:q524mv30t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -58.5, 50.5, 42.5)",
+        "id": "commonwealth:cj82ks15w"
+    },
+    {
+        "bbox": "ENVELOPE(-87.0, -51.0, 53.0, 25.0)",
+        "id": "commonwealth:z603vt70r"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08333, -66.56666, 47.81666, 42.96666)",
+        "id": "commonwealth:z603vg29z"
+    },
+    {
+        "bbox": "ENVELOPE(-81.0, -61.0, 45.0, 35.0)",
+        "id": "commonwealth:hq37vv62q"
+    },
+    {
+        "bbox": "ENVELOPE(-61.0, -52.5, 50.67, 46.5)",
+        "id": "commonwealth:8049g896t"
+    },
+    {
+        "bbox": "ENVELOPE(-79.0, -75.0, 40.0, 38.0)",
+        "id": "commonwealth:6t053p92x"
+    },
+    {
+        "bbox": "ENVELOPE(-75.1, -61.38333, 50.76666, 45.1)",
+        "id": "commonwealth:z603vg82g"
+    },
+    {
+        "bbox": "ENVELOPE(-75.1, -61.38333, 50.76666, 45.1)",
+        "id": "commonwealth:z603vg816"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, -60.0, 28.0, 9.0)",
+        "id": "commonwealth:z603vh21z"
+    },
+    {
+        "bbox": "ENVELOPE(-93.86861695455217, -76.24243312711491, 44.226050646609025, 32.839233164246835)",
+        "id": "commonwealth:z603vv18q"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -76.0, 40.0, 37.0)",
+        "id": "commonwealth:6w924p92r"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -0.0, 63.0, 0.0)",
+        "id": "commonwealth:kk91fq703"
+    },
+    {
+        "bbox": "ENVELOPE(-61.0, 3.0, 63.0, 2.0)",
+        "id": "commonwealth:kk91fq76r"
+    },
+    {
+        "bbox": "ENVELOPE(-61.81, -61.0, 16.52, 15.83)",
+        "id": "commonwealth:4m90f707x"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08484272884655, -71.03820126082375, 42.373938298425045, 42.339375396224604)",
+        "id": "commonwealth:3f462v496"
+    },
+    {
+        "bbox": "ENVELOPE(-74.103333, -73.888333, 40.911111, 40.596667)",
+        "id": "commonwealth:hx11z2944"
+    },
+    {
+        "bbox": "ENVELOPE(-58.242548962532055, -57.04241018016233, 6.516871192870281, 5.086645365629316)",
+        "id": "commonwealth:6t053s24d"
+    },
+    {
+        "bbox": "ENVELOPE(-180.0, 15.0, 75.0, -55.0)",
+        "id": "commonwealth:2514p126v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.01, 42.39, 42.33)",
+        "id": "commonwealth:dz010v66r"
+    },
+    {
+        "bbox": "ENVELOPE(-150.0, -20.0, 80.0, 10.0)",
+        "id": "commonwealth:z603vp60p"
+    },
+    {
+        "bbox": "ENVELOPE(-175.0, -30.0, 76.0, 10.0)",
+        "id": "commonwealth:z603vg549"
+    },
+    {
+        "bbox": "ENVELOPE(-160.0, -10.0, 90.0, -4.0)",
+        "id": "commonwealth:z603vp88c"
+    },
+    {
+        "bbox": "ENVELOPE(-150.0, -20.0, 80.0, 10.0)",
+        "id": "commonwealth:z603vp538"
+    },
+    {
+        "bbox": "ENVELOPE(-120.0, -55.0, 54.0, 8.0)",
+        "id": "commonwealth:mg74t290k"
+    },
+    {
+        "bbox": "ENVELOPE(-145.0, -40.0, 75.0, 20.0)",
+        "id": "commonwealth:z603vp70x"
+    },
+    {
+        "bbox": "ENVELOPE(152.0, -18.0, 90.0, 0.0)",
+        "id": "commonwealth:z603vp55t"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -52.0, 54.0, 29.0)",
+        "id": "commonwealth:z603vs00v"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -52.0, 54.0, 29.0)",
+        "id": "commonwealth:6t053n91f"
+    },
+    {
+        "bbox": "ENVELOPE(-84.31666, -75.4, 36.58333, 33.75)",
+        "id": "commonwealth:z603vg638"
+    },
+    {
+        "bbox": "ENVELOPE(-64.04, -61.15, 46.18, 45.25)",
+        "id": "commonwealth:ws859h204"
+    },
+    {
+        "bbox": "ENVELOPE(-64.49, -63.35, 46.3, 45.4)",
+        "id": "commonwealth:ws859h22p"
+    },
+    {
+        "bbox": "ENVELOPE(-87.5, -86.75, 30.5, 30.25)",
+        "id": "commonwealth:q524n491c"
+    },
+    {
+        "bbox": "ENVELOPE(-76.533333, -76.033333, 44.266667, 43.416667)",
+        "id": "commonwealth:hx11z108v"
+    },
+    {
+        "bbox": "ENVELOPE(-130.0, -24.0, 66.0, 6.0)",
+        "id": "commonwealth:z603vg55k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.51275538154462, -73.47751657693043, 42.16433683824637, 40.225825612560726)",
+        "id": "commonwealth:q524nj44g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.3342, -73.2342, 40.5749, 40.5057)",
+        "id": "commonwealth:z603vv23k"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, -75.5, 30.6, 25.0)",
+        "id": "commonwealth:q524n489b"
+    },
+    {
+        "bbox": "ENVELOPE(-92.6, -84.05, 30.6, 25.0)",
+        "id": "commonwealth:q524n4882"
+    },
+    {
+        "bbox": "ENVELOPE(-74.75, -72.25, 41.85, 40.5)",
+        "id": "commonwealth:hq37vv983"
+    },
+    {
+        "bbox": "ENVELOPE(-73.603611, -73.571667, 43.307222, 43.155833)",
+        "id": "commonwealth:hx11z207s"
+    },
+    {
+        "bbox": "ENVELOPE(-88.0, -67.0, 46.0, 34.0)",
+        "id": "commonwealth:z603vp72g"
+    },
+    {
+        "bbox": "ENVELOPE(-54.021667, -53.921111, 47.318333, 47.222778)",
+        "id": "commonwealth:6108vv16r"
+    },
+    {
+        "bbox": "ENVELOPE(-52.704167, -52.668056, 47.585278, 47.565556)",
+        "id": "commonwealth:6108vv30k"
+    },
+    {
+        "bbox": "ENVELOPE(-70.928889, -70.300833, 47.200278, 46.854167)",
+        "id": "commonwealth:hx11z066j"
+    },
+    {
+        "bbox": "ENVELOPE(162.0, 32.0, 80.0, 30.0)",
+        "id": "commonwealth:hq37vv34j"
+    },
+    {
+        "bbox": "ENVELOPE(-92.99972094155264, -52.71322241388319, 33.88202330509543, 8.801907365429443)",
+        "id": "commonwealth:x633f918m"
+    },
+    {
+        "bbox": "ENVELOPE(-71.214444, -71.203889, 46.816389, 46.812222)",
+        "id": "commonwealth:hx11z072p"
+    },
+    {
+        "bbox": "ENVELOPE(-92.5, -79.4, 43.5, 33.3)",
+        "id": "commonwealth:z603vs570"
+    },
+    {
+        "bbox": "ENVELOPE(-88.0, -74.0, 49.0, 31.0)",
+        "id": "commonwealth:z603vt177"
+    },
+    {
+        "bbox": "ENVELOPE(-84.08333, -75.58333, 30.5, 25.0)",
+        "id": "commonwealth:z603vg19q"
+    },
+    {
+        "bbox": "ENVELOPE(-87.256389, -87.194722, 30.426389, 30.396389)",
+        "id": "commonwealth:hx11z2766"
+    },
+    {
+        "bbox": "ENVELOPE(-83.5, -72.5, 45.75, 40.25)",
+        "id": "commonwealth:z603vq526"
+    },
+    {
+        "bbox": "ENVELOPE(-60.0, -59.941667, 45.928611, 45.880278)",
+        "id": "commonwealth:hx11z0241"
+    },
+    {
+        "bbox": "ENVELOPE(-59.99, -59.978889, 45.895278, 45.888611)",
+        "id": "commonwealth:hx11z050n"
+    },
+    {
+        "bbox": "ENVELOPE(-64.298055, -64.284722, 45.869167, 45.859722)",
+        "id": "commonwealth:hx11z001q"
+    },
+    {
+        "bbox": "ENVELOPE(-64.294167, -64.289167, 45.865833, 45.861389)",
+        "id": "commonwealth:hx11z0063"
+    },
+    {
+        "bbox": "ENVELOPE(-64.294167, -64.289167, 45.865833, 45.861389)",
+        "id": "commonwealth:hx11z004j"
+    },
+    {
+        "bbox": "ENVELOPE(-64.2925, -64.290278, 45.865278, 45.863611)",
+        "id": "commonwealth:hx11z0020"
+    },
+    {
+        "bbox": "ENVELOPE(-63.686111, -63.4475, 44.738056, 44.48)",
+        "id": "commonwealth:hx11z038c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.388889, -73.386111, 43.8425, 43.840556)",
+        "id": "commonwealth:hx11z1760"
+    },
+    {
+        "bbox": "ENVELOPE(-5.5, -5.25, 36.25, 35.85)",
+        "id": "commonwealth:z603vt82j"
+    },
+    {
+        "bbox": "ENVELOPE(-5.5, -5.3, 36.2, 36.1)",
+        "id": "commonwealth:z603vt78z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.23, -70.85, 41.88, 41.48)",
+        "id": "commonwealth:cj82kx86p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.566667, -73.533333, 43.133333, 43.066667)",
+        "id": "commonwealth:p8418t756"
+    },
+    {
+        "bbox": "ENVELOPE(-78.9, -78.57, 34.15, 33.68)",
+        "id": "commonwealth:cj82kx908"
+    },
+    {
+        "bbox": "ENVELOPE(-76.520556, -76.502778, 43.47, 43.454444)",
+        "id": "commonwealth:hx11z129m"
+    },
+    {
+        "bbox": "ENVELOPE(-62.0, -59.4, 47.1, 45.3)",
+        "id": "commonwealth:z603vw08p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.571667, -73.546111, 45.5125, 45.484444)",
+        "id": "commonwealth:hx11z084g"
+    },
+    {
+        "bbox": "ENVELOPE(-72.21896197047138, -72.1858818660463, 19.77776063501661, 19.74141523962923)",
+        "id": "commonwealth:z603vt58g"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0435, -71.0025, 42.2234, 42.1951)",
+        "id": "commonwealth:z603vv407"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0435, -71.0025, 42.2234, 42.1951)",
+        "id": "commonwealth:cj82m019d"
+    },
+    {
+        "bbox": "ENVELOPE(-71.2175, -71.212222, 46.817778, 46.814167)",
+        "id": "commonwealth:hx11z0747"
+    },
+    {
+        "bbox": "ENVELOPE(-61.81, -61.59, 12.24, 11.98)",
+        "id": "commonwealth:q524n5471"
+    },
+    {
+        "bbox": "ENVELOPE(-60.063611, -59.914444, 45.934722, 45.869167)",
+        "id": "commonwealth:hx11z044h"
+    },
+    {
+        "bbox": "ENVELOPE(-82.78, -82.74, 23.03, 22.98)",
+        "id": "commonwealth:q524n5136"
+    },
+    {
+        "bbox": "ENVELOPE(-82.0, -77.0, 42.0, 40.0)",
+        "id": "commonwealth:z603vr28b"
+    },
+    {
+        "bbox": "ENVELOPE(-75.25, -75.05, 40.05, 39.85)",
+        "id": "commonwealth:z603vv90f"
+    },
+    {
+        "bbox": "ENVELOPE(-77.08843039885429, -76.95307879989726, 38.93749084523002, 38.84050882112648)",
+        "id": "commonwealth:z603vp02s"
+    },
+    {
+        "bbox": "ENVELOPE(-75.3, -75.2, 40.2, 40.0)",
+        "id": "commonwealth:z603vt03w"
+    },
+    {
+        "bbox": "ENVELOPE(-74.26, -73.75, 41.08, 40.4)",
+        "id": "commonwealth:q524mv49j"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5, -69.5, 45.0, 43.75)",
+        "id": "commonwealth:z603vr32x"
+    },
+    {
+        "bbox": "ENVELOPE(-85.81, -85.74, 38.29, 38.25)",
+        "id": "commonwealth:q524mv03x"
+    },
+    {
+        "bbox": "ENVELOPE(-76.793333, -76.79, 40.87694, 40.875)",
+        "id": "commonwealth:hx11z399q"
+    },
+    {
+        "bbox": "ENVELOPE(-76.521667, -76.503333, 43.469722, 43.4575)",
+        "id": "commonwealth:hx11z117t"
+    },
+    {
+        "bbox": "ENVELOPE(-60.0, -59.95, 45.95, 45.85)",
+        "id": "commonwealth:z603vr26s"
+    },
+    {
+        "bbox": "ENVELOPE(-73.711667, -73.709722, 43.420833, 43.419444)",
+        "id": "commonwealth:hx11z190t"
+    },
+    {
+        "bbox": "ENVELOPE(-73.252778, -73.25, 45.297222, 45.294167)",
+        "id": "commonwealth:hx11z188s"
+    },
+    {
+        "bbox": "ENVELOPE(-81.6, -81.4, 30.75, 30.65)",
+        "id": "commonwealth:z603vr40m"
+    },
+    {
+        "bbox": "ENVELOPE(-60.0, -59.9, 45.95, 45.85)",
+        "id": "commonwealth:z603vt487"
+    },
+    {
+        "bbox": "ENVELOPE(-81.397777, -81.38527, 31.1375, 31.1325)",
+        "id": "commonwealth:hx11z4653"
+    },
+    {
+        "bbox": "ENVELOPE(-81.452777, -81.44361, 30.93055, 30.925)",
+        "id": "commonwealth:hx11z4696"
+    },
+    {
+        "bbox": "ENVELOPE(-71.211389, -71.199167, 46.851389, 46.843056)",
+        "id": "commonwealth:hx11z0704"
+    },
+    {
+        "bbox": "ENVELOPE(-73.252778, -73.25, 45.297222, 45.294167)",
+        "id": "commonwealth:hx11z1867"
+    },
+    {
+        "bbox": "ENVELOPE(-68.812222, -68.811111, 44.468333, 44.4675)",
+        "id": "commonwealth:hx11z148t"
+    },
+    {
+        "bbox": "ENVELOPE(-73.596111, -73.59, 43.265556, 43.260833)",
+        "id": "commonwealth:hx11z170b"
+    },
+    {
+        "bbox": "ENVELOPE(-73.596111, -73.59, 43.265556, 43.260833)",
+        "id": "commonwealth:hx11z150v"
+    },
+    {
+        "bbox": "ENVELOPE(-59.982222, -59.978889, 45.911111, 45.908333)",
+        "id": "commonwealth:hx11z042z"
+    },
+    {
+        "bbox": "ENVELOPE(-73.588611, -73.574444, 43.266944, 43.257778)",
+        "id": "commonwealth:hx11z166r"
+    },
+    {
+        "bbox": "ENVELOPE(-73.710278, -73.704167, 43.419444, 43.415)",
+        "id": "commonwealth:hx11z1999"
+    },
+    {
+        "bbox": "ENVELOPE(-83.22, -83.1, 23.0, 22.92)",
+        "id": "commonwealth:q524n512x"
+    },
+    {
+        "bbox": "ENVELOPE(-85.0, -83.1, 23.0, 21.25)",
+        "id": "commonwealth:q524n511n"
+    },
+    {
+        "bbox": "ENVELOPE(-73.16, -73.02, 42.34, 42.25)",
+        "id": "commonwealth:0r96fq62v"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07, -71.04, 42.37, 42.34)",
+        "id": "commonwealth:cj82m7403"
+    },
+    {
+        "bbox": "ENVELOPE(-71.13, -70.92861, 42.39694, 42.31638)",
+        "id": "commonwealth:z603vg043"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1208009111316, -70.98853281879646, 42.41897658328731, 42.30985724043311)",
+        "id": "commonwealth:3f462w352"
+    },
+    {
+        "bbox": "ENVELOPE(-71.088056, -70.960278, 42.389722, 42.329722)",
+        "id": "commonwealth:hx11xz487"
+    },
+    {
+        "bbox": "ENVELOPE(-71.17650367125523, -70.95130075948265, 42.429255526010664, 42.27661589947311)",
+        "id": "commonwealth:3f462w840"
+    },
+    {
+        "bbox": "ENVELOPE(-52.866667, -52.858333, 47.029167, 47.020833)",
+        "id": "commonwealth:6108vv22w"
+    },
+    {
+        "bbox": "ENVELOPE(-53.171944, -53.16, 47.742222, 47.733611)",
+        "id": "commonwealth:6108vv15g"
+    },
+    {
+        "bbox": "ENVELOPE(-68.824167, -68.781944, 44.404444, 44.379167)",
+        "id": "commonwealth:hx11z2499"
+    },
+    {
+        "bbox": "ENVELOPE(-52.911667, -52.851389, 47.064167, 46.9975)",
+        "id": "commonwealth:6108vv20b"
+    },
+    {
+        "bbox": "ENVELOPE(-76.797778, -76.7825, 40.8775, 40.870278)",
+        "id": "commonwealth:hx11z2392"
+    },
+    {
+        "bbox": "ENVELOPE(-78.767777, -78.76388, 39.65416, 39.64777)",
+        "id": "commonwealth:hx11z4211"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z409r"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z531g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5925, -73.5775, 43.27, 43.25583)",
+        "id": "commonwealth:hx11z383t"
+    },
+    {
+        "bbox": "ENVELOPE(-73.585, -73.57972, 43.26583, 43.25861)",
+        "id": "commonwealth:hx11z391h"
+    },
+    {
+        "bbox": "ENVELOPE(-73.585, -73.57972, 43.26583, 43.25861)",
+        "id": "commonwealth:hx11z3932"
+    },
+    {
+        "bbox": "ENVELOPE(-73.585, -73.57972, 43.26583, 43.25861)",
+        "id": "commonwealth:hx11z389g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.595, -73.579167, 43.269722, 43.254167)",
+        "id": "commonwealth:hx11xz419"
+    },
+    {
+        "bbox": "ENVELOPE(-73.461666, -73.39083, 44.03222, 44.01472)",
+        "id": "commonwealth:hx11z3711"
+    },
+    {
+        "bbox": "ENVELOPE(-53.963333, -53.960833, 47.25, 47.248333)",
+        "id": "commonwealth:6108vv24f"
+    },
+    {
+        "bbox": "ENVELOPE(-66.08, -66.06, 45.268056, 45.254722)",
+        "id": "commonwealth:hx11z032q"
+    },
+    {
+        "bbox": "ENVELOPE(-79.239722, -79.235278, 40.242222, 40.239167)",
+        "id": "commonwealth:hx11z2171"
+    },
+    {
+        "bbox": "ENVELOPE(-79.243888, -79.23, 40.24416, 40.23555)",
+        "id": "commonwealth:hx11z405n"
+    },
+    {
+        "bbox": "ENVELOPE(-79.239722, -79.235278, 40.242222, 40.239167)",
+        "id": "commonwealth:6108vv588"
+    },
+    {
+        "bbox": "ENVELOPE(-79.243888, -79.23, 40.24416, 40.23555)",
+        "id": "commonwealth:hx11z4076"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0016, -73.5702, 41.2101, 41.184)",
+        "id": "commonwealth:z603vv254"
+    },
+    {
+        "bbox": "ENVELOPE(-75.471944, -75.466945, 43.216667, 43.214167)",
+        "id": "commonwealth:hx11z156h"
+    },
+    {
+        "bbox": "ENVELOPE(-79.065556, -79.056667, 43.265, 43.260556)",
+        "id": "commonwealth:hx11z1140"
+    },
+    {
+        "bbox": "ENVELOPE(-79.1275, -79.011111, 43.285833, 43.220833)",
+        "id": "commonwealth:hx11z132x"
+    },
+    {
+        "bbox": "ENVELOPE(-79.075833, -79.028889, 43.2725, 43.245833)",
+        "id": "commonwealth:hx11xz46p"
+    },
+    {
+        "bbox": "ENVELOPE(-76.520556, -76.502778, 43.47, 43.454444)",
+        "id": "commonwealth:hx11z1272"
+    },
+    {
+        "bbox": "ENVELOPE(-76.520556, -76.502778, 43.47, 43.454444)",
+        "id": "commonwealth:hx11z125h"
+    },
+    {
+        "bbox": "ENVELOPE(-75.469722, -75.453056, 43.211944, 43.202778)",
+        "id": "commonwealth:hx11z152d"
+    },
+    {
+        "bbox": "ENVELOPE(-75.456667, -75.453611, 43.211389, 43.209444)",
+        "id": "commonwealth:hx11z154z"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721111, -73.694722, 43.424722, 43.411389)",
+        "id": "commonwealth:hx11xz43v"
+    },
+    {
+        "bbox": "ENVELOPE(-73.716667, -73.695556, 43.426389, 43.410833)",
+        "id": "commonwealth:hx11z196g"
+    },
+    {
+        "bbox": "ENVELOPE(-77.618889, -77.09, 44.201667, 44.046111)",
+        "id": "commonwealth:hx11z0925"
+    },
+    {
+        "bbox": "ENVELOPE(-75.26, -75.06, 20.07, 19.89)",
+        "id": "commonwealth:q524n510c"
+    },
+    {
+        "bbox": "ENVELOPE(-63.686389, -63.448889, 44.754722, 44.427222)",
+        "id": "commonwealth:hx11z018w"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -91.0, 19.0, 18.0)",
+        "id": "commonwealth:q524n496r"
+    },
+    {
+        "bbox": "ENVELOPE(-79.883333, -76.033333, 44.35, 42.933333)",
+        "id": "commonwealth:hx11z090m"
+    },
+    {
+        "bbox": "ENVELOPE(-60.030277, -59.95361, 45.92888, 45.87138)",
+        "id": "commonwealth:6108vw19s"
+    },
+    {
+        "bbox": "ENVELOPE(-70.64295981267684, -70.41355692364235, 41.72098189265358, 41.54133741686053)",
+        "id": "commonwealth:cj82kr37q"
+    },
+    {
+        "bbox": "ENVELOPE(-88.040555, -88.03083, 30.69138, 30.68583)",
+        "id": "commonwealth:hx11z479f"
+    },
+    {
+        "bbox": "ENVELOPE(-74.3, -73.7, 41.05, 40.4)",
+        "id": "commonwealth:z603vw04k"
+    },
+    {
+        "bbox": "ENVELOPE(-52.683333, -52.678056, 47.564722, 47.561944)",
+        "id": "commonwealth:6108vv38s"
+    },
+    {
+        "bbox": "ENVELOPE(-73.091389, -72.338889, 43.745833, 43.250278)",
+        "id": "commonwealth:hx11z1603"
+    },
+    {
+        "bbox": "ENVELOPE(-73.712778, -73.698611, 43.419444, 43.412222)",
+        "id": "commonwealth:6108vv545"
+    },
+    {
+        "bbox": "ENVELOPE(-60.6607110937704, -59.42644385363524, 46.66463893473259, 45.3996572102807)",
+        "id": "commonwealth:hx11z016b"
+    },
+    {
+        "bbox": "ENVELOPE(-80.01, -80.006944, 40.4425, 40.439167)",
+        "id": "commonwealth:hx11z225q"
+    },
+    {
+        "bbox": "ENVELOPE(-80.5153, -80.315, 32.2437, 32.0538)",
+        "id": "commonwealth:z603vt25x"
+    },
+    {
+        "bbox": "ENVELOPE(-76.521111, -76.501944, 43.47, 43.458056)",
+        "id": "commonwealth:hx11z119c"
+    },
+    {
+        "bbox": "ENVELOPE(-68.03, -67.97, 10.5, 10.46)",
+        "id": "commonwealth:q524n5047"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1351, -71.0735, 46.5132, 46.4742)",
+        "id": "commonwealth:7h149v43f"
+    },
+    {
+        "bbox": "ENVELOPE(-71.467777, -71.15611, 41.74916, 41.39944)",
+        "id": "commonwealth:hx11z3134"
+    },
+    {
+        "bbox": "ENVELOPE(-70.89222559532483, -70.88604067520907, 42.52635556955499, 42.52118747046481)",
+        "id": "commonwealth:9s161g69t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.031944, -73.96138, 40.48583, 40.3925)",
+        "id": "commonwealth:hx11z417f"
+    },
+    {
+        "bbox": "ENVELOPE(-61.03, -60.93, 14.1, 13.98)",
+        "id": "commonwealth:6t053r16h"
+    },
+    {
+        "bbox": "ENVELOPE(-71.083333, -71.025, 42.393333, 42.358333)",
+        "id": "commonwealth:z603vh49n"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07583216199164, -71.04738001165747, 42.389738847000956, 42.36338719098675)",
+        "id": "commonwealth:z603vj304"
+    },
+    {
+        "bbox": "ENVELOPE(-61.75, -61.7, 16.02, 15.97)",
+        "id": "commonwealth:q524n536h"
+    },
+    {
+        "bbox": "ENVELOPE(-79.9, -79.8, 34.78, 34.75)",
+        "id": "commonwealth:z603vr65g"
+    },
+    {
+        "bbox": "ENVELOPE(-79.9, -79.8, 34.78, 34.75)",
+        "id": "commonwealth:wd3768558"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -73.95, 41.33, 41.2)",
+        "id": "commonwealth:z603vs898"
+    },
+    {
+        "bbox": "ENVELOPE(-73.710278, -73.704167, 43.419444, 43.415)",
+        "id": "commonwealth:hx11z2014"
+    },
+    {
+        "bbox": "ENVELOPE(-75.481667, -75.449722, 44.752222, 44.736389)",
+        "id": "commonwealth:hx11z094q"
+    },
+    {
+        "bbox": "ENVELOPE(-71.2325, -71.1975, 46.821111, 46.793333)",
+        "id": "commonwealth:hx11xz45d"
+    },
+    {
+        "bbox": "ENVELOPE(-79.64, -79.61, 40.36, 40.35)",
+        "id": "commonwealth:q524n482d"
+    },
+    {
+        "bbox": "ENVELOPE(-79.7, -79.6, 40.4, 40.3)",
+        "id": "commonwealth:z603vv50g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.659432, -73.59922, 43.014924, 42.973605)",
+        "id": "commonwealth:z603vw064"
+    },
+    {
+        "bbox": "ENVELOPE(-60.07, -59.95, 45.93, 45.87)",
+        "id": "commonwealth:6t053n83r"
+    },
+    {
+        "bbox": "ENVELOPE(-60.03, -59.94, 45.93, 45.87)",
+        "id": "commonwealth:q524n4750"
+    },
+    {
+        "bbox": "ENVELOPE(-59.989444, -59.98, 45.895, 45.888611)",
+        "id": "commonwealth:hx11z0462"
+    },
+    {
+        "bbox": "ENVELOPE(-59.988055, -59.97222, 45.89611, 45.88861)",
+        "id": "commonwealth:hx11z5196"
+    },
+    {
+        "bbox": "ENVELOPE(-81.6, -81.46, 23.1, 23.02)",
+        "id": "commonwealth:q524n508b"
+    },
+    {
+        "bbox": "ENVELOPE(-82.41706009691757, -82.30132901732254, 23.17022782385232, 23.098205825399134)",
+        "id": "commonwealth:x633f855j"
+    },
+    {
+        "bbox": "ENVELOPE(-74.25, -74.15, 11.27, 11.17)",
+        "id": "commonwealth:q524n502p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.763055, -73.74333, 42.65583, 42.64583)",
+        "id": "commonwealth:hx11z3690"
+    },
+    {
+        "bbox": "ENVELOPE(-73.7838145822359, -73.71625262982393, 42.68379948245691, 42.62533807444537)",
+        "id": "commonwealth:hx11z365w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.763055, -73.74333, 42.65583, 42.64583)",
+        "id": "commonwealth:hx11z367f"
+    },
+    {
+        "bbox": "ENVELOPE(-73.759167, -73.743333, 42.656667, 42.644444)",
+        "id": "commonwealth:6108vv502"
+    },
+    {
+        "bbox": "ENVELOPE(-73.763055, -73.74333, 42.65583, 42.64583)",
+        "id": "commonwealth:hx11z361s"
+    },
+    {
+        "bbox": "ENVELOPE(-73.763055, -73.74333, 42.65583, 42.64583)",
+        "id": "commonwealth:hx11z363b"
+    },
+    {
+        "bbox": "ENVELOPE(-74.01944, -73.988889, 40.722222, 40.7)",
+        "id": "commonwealth:p8418t37s"
+    },
+    {
+        "bbox": "ENVELOPE(-74.066667, -73.95, 40.766667, 40.65)",
+        "id": "commonwealth:p8418t51m"
+    },
+    {
+        "bbox": "ENVELOPE(-74.036944, -73.95611, 40.76472, 40.67)",
+        "id": "commonwealth:hx11z359r"
+    },
+    {
+        "bbox": "ENVELOPE(-75.20630300895874, -75.09728705561324, 39.98345871386037, 39.9276595799621)",
+        "id": "commonwealth:z603vq66j"
+    },
+    {
+        "bbox": "ENVELOPE(-69.93, -69.86, 18.5, 18.46)",
+        "id": "commonwealth:q524n521w"
+    },
+    {
+        "bbox": "ENVELOPE(-81.10346951892204, -81.08187012049541, 32.08660720129073, 32.07175545953064)",
+        "id": "commonwealth:q524nf92h"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0912159021927, -76.95186511814912, 38.92876858893671, 38.84385264060246)",
+        "id": "commonwealth:6t053p72f"
+    },
+    {
+        "bbox": "ENVELOPE(-80.416667, -78.55, 42.316667, 39.583333)",
+        "id": "commonwealth:hx11z237h"
+    },
+    {
+        "bbox": "ENVELOPE(-76.543333, -75.638056, 44.61, 44.194722)",
+        "id": "commonwealth:hx11z1069"
+    },
+    {
+        "bbox": "ENVELOPE(-64.305556, -64.235, 45.884167, 45.819444)",
+        "id": "commonwealth:hx11xz99q"
+    },
+    {
+        "bbox": "ENVELOPE(-73.716666, -73.36666, 44.05, 43.25)",
+        "id": "commonwealth:hx11z345d"
+    },
+    {
+        "bbox": "ENVELOPE(-73.712778, -73.698611, 43.419444, 43.412222)",
+        "id": "commonwealth:hx11z197r"
+    },
+    {
+        "bbox": "ENVELOPE(-73.716667, -73.695556, 43.426389, 43.410833)",
+        "id": "commonwealth:hx11z194x"
+    },
+    {
+        "bbox": "ENVELOPE(-73.659432, -73.59922, 43.014924, 42.973605)",
+        "id": "commonwealth:z603vs73c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.716667, -73.695556, 43.426389, 43.410833)",
+        "id": "commonwealth:hx11z192c"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721944, -73.686667, 43.433333, 43.399167)",
+        "id": "commonwealth:hx11z209b"
+    },
+    {
+        "bbox": "ENVELOPE(-76.8, -75.6, 37.55, 36.75)",
+        "id": "commonwealth:cj82m1172"
+    },
+    {
+        "bbox": "ENVELOPE(-52.688889, -52.674167, 47.574444, 47.561389)",
+        "id": "commonwealth:6108vv324"
+    },
+    {
+        "bbox": "ENVELOPE(-73.594166, -73.57277, 43.27, 43.25222)",
+        "id": "commonwealth:hx11z387x"
+    },
+    {
+        "bbox": "ENVELOPE(-80.03, -79.89, 40.55, 40.43)",
+        "id": "commonwealth:q524mv45f"
+    },
+    {
+        "bbox": "ENVELOPE(-80.03, -79.89, 40.55, 40.43)",
+        "id": "commonwealth:cj82m570d"
+    },
+    {
+        "bbox": "ENVELOPE(-79.085278, -78.846944, 43.3175, 43.220833)",
+        "id": "commonwealth:hx11z112f"
+    },
+    {
+        "bbox": "ENVELOPE(-78.767222, -78.76361, 39.65388, 39.64777)",
+        "id": "commonwealth:hx11z423k"
+    },
+    {
+        "bbox": "ENVELOPE(-87.215278, -87.207778, 30.410556, 30.406111)",
+        "id": "commonwealth:hx11z233d"
+    },
+    {
+        "bbox": "ENVELOPE(-81.3125, -81.310556, 29.898611, 29.896389)",
+        "id": "commonwealth:hx11z076s"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z415w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.415, -73.365833, 43.852778, 43.8275)",
+        "id": "commonwealth:6108vv52m"
+    },
+    {
+        "bbox": "ENVELOPE(-73.465556, -73.388611, 44.041111, 43.989444)",
+        "id": "commonwealth:hx11z211c"
+    },
+    {
+        "bbox": "ENVELOPE(-75.462222, -75.42666, 43.21388, 43.19611)",
+        "id": "commonwealth:hx11z349h"
+    },
+    {
+        "bbox": "ENVELOPE(-75.462222, -75.42666, 43.21388, 43.19611)",
+        "id": "commonwealth:hx11z351j"
+    },
+    {
+        "bbox": "ENVELOPE(-74.001667, -73.9675, 41.333056, 41.311944)",
+        "id": "commonwealth:hx11z292k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.586944, -73.57638, 43.16583, 43.15527)",
+        "id": "commonwealth:hx11z3533"
+    },
+    {
+        "bbox": "ENVELOPE(-60.000833, -59.95361, 45.92888, 45.92888)",
+        "id": "commonwealth:hx11z513j"
+    },
+    {
+        "bbox": "ENVELOPE(-60.000833, -59.95361, 45.92888, 45.92888)",
+        "id": "commonwealth:hx11z5153"
+    },
+    {
+        "bbox": "ENVELOPE(-60.000833, -59.95361, 45.92888, 45.92888)",
+        "id": "commonwealth:hx11z5438"
+    },
+    {
+        "bbox": "ENVELOPE(-60.0, -59.941667, 45.928611, 45.880278)",
+        "id": "commonwealth:hx11z020x"
+    },
+    {
+        "bbox": "ENVELOPE(-60.0, -59.941667, 45.928611, 45.880278)",
+        "id": "commonwealth:hx11z022g"
+    },
+    {
+        "bbox": "ENVELOPE(-66.146944, -65.994167, 45.286667, 45.234444)",
+        "id": "commonwealth:hx11z054r"
+    },
+    {
+        "bbox": "ENVELOPE(-63.366111, -62.8, 46.383056, 46.111944)",
+        "id": "commonwealth:hx11z008n"
+    },
+    {
+        "bbox": "ENVELOPE(-80.67, -79.45, 9.65, 8.85)",
+        "id": "commonwealth:q524n4971"
+    },
+    {
+        "bbox": "ENVELOPE(-66.185, -65.983333, 45.293056, 45.194167)",
+        "id": "commonwealth:hx11z0305"
+    },
+    {
+        "bbox": "ENVELOPE(-73.599444, -73.578889, 43.269722, 43.255278)",
+        "id": "commonwealth:hx11z1689"
+    },
+    {
+        "bbox": "ENVELOPE(-64.533333, -61.666667, 49.95, 49.05)",
+        "id": "commonwealth:hx11z0569"
+    },
+    {
+        "bbox": "ENVELOPE(-61.983333, -59.633333, 47.033333, 45.166667)",
+        "id": "commonwealth:hx11z0127"
+    },
+    {
+        "bbox": "ENVELOPE(-61.6, -59.633333, 47.25, 45.45)",
+        "id": "commonwealth:hx11z014s"
+    },
+    {
+        "bbox": "ENVELOPE(-64.4, -61.95, 47.05, 45.95)",
+        "id": "commonwealth:z603vr94x"
+    },
+    {
+        "bbox": "ENVELOPE(-64.4, -61.95, 47.05, 45.95)",
+        "id": "commonwealth:6t053n77m"
+    },
+    {
+        "bbox": "ENVELOPE(-80.25, -79.75, 32.9, 32.5)",
+        "id": "commonwealth:z603vs51b"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z3797"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z545t"
+    },
+    {
+        "bbox": "ENVELOPE(-80.01, -80.006944, 40.4425, 40.439167)",
+        "id": "commonwealth:6108vv56q"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z413b"
+    },
+    {
+        "bbox": "ENVELOPE(-74.95, -74.5, 40.38, 40.08)",
+        "id": "commonwealth:z603vr671"
+    },
+    {
+        "bbox": "ENVELOPE(-74.95, -74.5, 40.38, 40.08)",
+        "id": "commonwealth:wd376857t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.25, -73.67, 41.3, 40.8)",
+        "id": "commonwealth:z603vs919"
+    },
+    {
+        "bbox": "ENVELOPE(-76.8, -74.75, 40.0, 36.68333)",
+        "id": "commonwealth:hx11z4190"
+    },
+    {
+        "bbox": "ENVELOPE(-81.4475, -81.26583, 31.35083, 31.00694)",
+        "id": "commonwealth:hx11z527w"
+    },
+    {
+        "bbox": "ENVELOPE(-73.666667, -73.599167, 43.019167, 42.964167)",
+        "id": "commonwealth:hx11z286f"
+    },
+    {
+        "bbox": "ENVELOPE(-73.666667, -73.599167, 43.019167, 42.964167)",
+        "id": "commonwealth:hx11z282b"
+    },
+    {
+        "bbox": "ENVELOPE(-70.066667, -69.566667, 44.866667, 43.683333)",
+        "id": "commonwealth:hx11z1582"
+    },
+    {
+        "bbox": "ENVELOPE(-63.698888, -63.35555, 45.33722, 44.69722)",
+        "id": "commonwealth:hx11z501r"
+    },
+    {
+        "bbox": "ENVELOPE(-76.6, -71.033333, 46.9, 44.05)",
+        "id": "commonwealth:hx11z0683"
+    },
+    {
+        "bbox": "ENVELOPE(-53.995278, -53.921111, 47.259444, 47.222778)",
+        "id": "commonwealth:6108vv189"
+    },
+    {
+        "bbox": "ENVELOPE(-70.23, -69.73777, 44.34972, 43.5475)",
+        "id": "commonwealth:hx11z305f"
+    },
+    {
+        "bbox": "ENVELOPE(-77.666111, -76.173889, 44.280556, 43.83)",
+        "id": "commonwealth:hx11z144q"
+    },
+    {
+        "bbox": "ENVELOPE(-80.08065286070142, -79.78783375525094, 32.9056572597111, 32.64303614692328)",
+        "id": "commonwealth:z603vs40t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.8, -74.15, 40.7, 40.45)",
+        "id": "commonwealth:z603vt76d"
+    },
+    {
+        "bbox": "ENVELOPE(-52.686667, -52.6775, 47.565, 47.560833)",
+        "id": "commonwealth:6108vv28j"
+    },
+    {
+        "bbox": "ENVELOPE(-85.5, -82.5, 47.0, 45.75)",
+        "id": "commonwealth:6t053n795"
+    },
+    {
+        "bbox": "ENVELOPE(-73.97, -73.95, 41.25, 41.23)",
+        "id": "commonwealth:z603vt508"
+    },
+    {
+        "bbox": "ENVELOPE(-63.57, -63.569167, 44.621667, 44.621111)",
+        "id": "commonwealth:6108vv44x"
+    },
+    {
+        "bbox": "ENVELOPE(-76.693888, -76.61305, 34.72083, 34.68277)",
+        "id": "commonwealth:hx11z4297"
+    },
+    {
+        "bbox": "ENVELOPE(-76.628333, -76.58944, 36.06583, 36.05055)",
+        "id": "commonwealth:hx11z435c"
+    },
+    {
+        "bbox": "ENVELOPE(-61.1, -60.99, 14.63, 14.53)",
+        "id": "commonwealth:q524n5446"
+    },
+    {
+        "bbox": "ENVELOPE(-59.988055, -59.97222, 45.89611, 45.88861)",
+        "id": "commonwealth:hx11z5217"
+    },
+    {
+        "bbox": "ENVELOPE(-59.988055, -59.97222, 45.89611, 45.88861)",
+        "id": "commonwealth:hx11z523s"
+    },
+    {
+        "bbox": "ENVELOPE(-59.989444, -59.955, 45.903333, 45.888611)",
+        "id": "commonwealth:hx11z048m"
+    },
+    {
+        "bbox": "ENVELOPE(-60.000277, -59.95, 45.9275, 45.88472)",
+        "id": "commonwealth:hx11z517n"
+    },
+    {
+        "bbox": "ENVELOPE(-67.49, -67.12, 18.42, 18.0)",
+        "id": "commonwealth:q524n523f"
+    },
+    {
+        "bbox": "ENVELOPE(-81.329166, -81.26083, 29.92722, 29.85)",
+        "id": "commonwealth:hx11z547c"
+    },
+    {
+        "bbox": "ENVELOPE(-76.820833, -76.80611, 35.48, 35.46666)",
+        "id": "commonwealth:hx11z427p"
+    },
+    {
+        "bbox": "ENVELOPE(-77.950555, -77.94138, 34.04694, 34.03583)",
+        "id": "commonwealth:hx11z4318"
+    },
+    {
+        "bbox": "ENVELOPE(-66.753055, -66.68361, 45.09694, 45.04777)",
+        "id": "commonwealth:hx11z4874"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07439023259856, -71.02687166671726, 42.39638513762177, 42.32866765113661)",
+        "id": "commonwealth:z603vs791"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08693994501213, -71.03577205795422, 42.376380106514084, 42.335870906153254)",
+        "id": "commonwealth:3f462w86j"
+    },
+    {
+        "bbox": "ENVELOPE(-78.893611, -78.86083, 35.06555, 35.04638)",
+        "id": "commonwealth:hx11z433t"
+    },
+    {
+        "bbox": "ENVELOPE(-77.596388, -77.57527, 36.335, 36.325)",
+        "id": "commonwealth:hx11z437x"
+    },
+    {
+        "bbox": "ENVELOPE(-79.12, -79.08388, 36.07805, 36.06222)",
+        "id": "commonwealth:hx11z439g"
+    },
+    {
+        "bbox": "ENVELOPE(-77.05, -77.03, 35.11472, 35.0975)",
+        "id": "commonwealth:hx11z441h"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1955, -71.1839, 41.2956, 41.2824)",
+        "id": "commonwealth:7h149x16z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.1955, -71.1839, 41.2956, 41.2824)",
+        "id": "commonwealth:7h149z70z"
+    },
+    {
+        "bbox": "ENVELOPE(-80.478888, -80.45972, 35.675, 35.65944)",
+        "id": "commonwealth:hx11z4432"
+    },
+    {
+        "bbox": "ENVELOPE(-81.112778, -81.0725, 32.090278, 32.069167)",
+        "id": "commonwealth:hx11z280s"
+    },
+    {
+        "bbox": "ENVELOPE(-65.33885445100998, -65.30765721082965, 43.77414933359208, 43.747308084017796)",
+        "id": "commonwealth:hx11z0526"
+    },
+    {
+        "bbox": "ENVELOPE(-67.0679373274917, -67.03027714029785, 45.08599024633783, 45.062678585100905)",
+        "id": "commonwealth:hx11z4831"
+    },
+    {
+        "bbox": "ENVELOPE(-82.85, -82.31, 28.08, 27.45)",
+        "id": "commonwealth:z603vt94b"
+    },
+    {
+        "bbox": "ENVELOPE(-66.842777, -66.81861, 45.13138, 45.12583)",
+        "id": "commonwealth:hx11z485k"
+    },
+    {
+        "bbox": "ENVELOPE(-77.956944, -77.93277, 34.24277, 34.22388)",
+        "id": "commonwealth:hx11z445m"
+    },
+    {
+        "bbox": "ENVELOPE(-79.69, -79.64, 9.58, 9.54)",
+        "id": "commonwealth:q524n499k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.400833, -73.38194, 43.84222, 43.79444)",
+        "id": "commonwealth:hx11z539p"
+    },
+    {
+        "bbox": "ENVELOPE(-55.904722, -55.88, 51.985556, 51.957222)",
+        "id": "commonwealth:6108vv42c"
+    },
+    {
+        "bbox": "ENVELOPE(-74.07, -73.67, 41.31, 40.77)",
+        "id": "commonwealth:cj82m429g"
+    },
+    {
+        "bbox": "ENVELOPE(-74.07, -73.67, 41.31, 40.77)",
+        "id": "commonwealth:3f462w91d"
+    },
+    {
+        "bbox": "ENVELOPE(-180.0, 180.0, 90.0, -55.0)",
+        "id": "commonwealth:nc583505z"
+    },
+    {
+        "bbox": "ENVELOPE(-75.153056, -75.135278, 39.965278, 39.956111)",
+        "id": "commonwealth:hx11z296p"
+    },
+    {
+        "bbox": "ENVELOPE(-81.47, -80.5, 40.64, 39.32)",
+        "id": "commonwealth:3f4630054"
+    },
+    {
+        "bbox": "ENVELOPE(-65.3001, -65.2, 43.3428, 43.2641)",
+        "id": "commonwealth:9g54xk80f"
+    },
+    {
+        "bbox": "ENVELOPE(-65.2211, -65.1359, 43.4115, 43.2958)",
+        "id": "commonwealth:9g54xk820"
+    },
+    {
+        "bbox": "ENVELOPE(-71.4, -71.0, 41.9, 41.4)",
+        "id": "commonwealth:z603vs481"
+    },
+    {
+        "bbox": "ENVELOPE(-61.3651, -61.2957, 46.0318, 45.5625)",
+        "id": "commonwealth:ws859h247"
+    },
+    {
+        "bbox": "ENVELOPE(-64.35, -64.2, 44.14, 44.05)",
+        "id": "commonwealth:9g54xk927"
+    },
+    {
+        "bbox": "ENVELOPE(-65.1037, -64.3828, 44.0335, 43.3913)",
+        "id": "commonwealth:9g54xk863"
+    },
+    {
+        "bbox": "ENVELOPE(-65.1037, -64.3828, 44.0335, 43.3913)",
+        "id": "commonwealth:9g54xk84j"
+    },
+    {
+        "bbox": "ENVELOPE(-65.8, -65.47, 44.77, 44.57)",
+        "id": "commonwealth:cj82kx11m"
+    },
+    {
+        "bbox": "ENVELOPE(-80.5118, -80.3209, 32.33, 32.0603)",
+        "id": "commonwealth:7h149x797"
+    },
+    {
+        "bbox": "ENVELOPE(-64.45, -64.285, 46.2942, 46.1253)",
+        "id": "commonwealth:ws859h34g"
+    },
+    {
+        "bbox": "ENVELOPE(-74.29, -73.84, 40.79, 40.37)",
+        "id": "commonwealth:j3860847z"
+    },
+    {
+        "bbox": "ENVELOPE(-73.9, -73.733333, 41.1, 40.966667)",
+        "id": "commonwealth:p8418t578"
+    },
+    {
+        "bbox": "ENVELOPE(-76.45, -70.65, 41.75, 38.85)",
+        "id": "commonwealth:z603vt05f"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0749, -71.0471, 42.3865, 42.345)",
+        "id": "commonwealth:q524n340p"
+    },
+    {
+        "bbox": "ENVELOPE(-53.349722, -53.344444, 48.364722, 48.359444)",
+        "id": "commonwealth:6108vv13x"
+    },
+    {
+        "bbox": "ENVELOPE(-63.591944, -63.56805, 44.66222, 44.63694)",
+        "id": "commonwealth:hx11z504k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.434722, -73.4325, 44.03222, 44.03055)",
+        "id": "commonwealth:hx11z3818"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5275, -73.324167, 43.852778, 43.719444)",
+        "id": "commonwealth:hx11z203p"
+    },
+    {
+        "bbox": "ENVELOPE(-75.55, -73.95, 41.35, 38.9)",
+        "id": "commonwealth:z603vs59j"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08333, -66.93333, 47.45, 42.96666)",
+        "id": "commonwealth:z603vg30q"
+    },
+    {
+        "bbox": "ENVELOPE(-76.31115150888726, -73.17336318738528, 42.31034048316483, 38.33862542845006)",
+        "id": "commonwealth:z603vs04z"
+    },
+    {
+        "bbox": "ENVELOPE(-76.36995102536875, -73.07214006833794, 41.9001384795426, 38.3796681270406)",
+        "id": "commonwealth:6t053p847"
+    },
+    {
+        "bbox": "ENVELOPE(-76.33333, -73.66666, 41.05, 39.0)",
+        "id": "commonwealth:z603vg69x"
+    },
+    {
+        "bbox": "ENVELOPE(-76.44797166932084, -70.78471315580109, 45.30310916559623, 38.34860950847565)",
+        "id": "commonwealth:z603vp32h"
+    },
+    {
+        "bbox": "ENVELOPE(-76.3, -72.5, 46.6, 38.8)",
+        "id": "commonwealth:0r96fq77g"
+    },
+    {
+        "bbox": "ENVELOPE(-82.01, -32.29, 54.15, 24.04)",
+        "id": "commonwealth:cj82m272b"
+    },
+    {
+        "bbox": "ENVELOPE(-82.01, -32.29, 54.15, 24.04)",
+        "id": "commonwealth:cj82m308h"
+    },
+    {
+        "bbox": "ENVELOPE(-82.01, -32.29, 54.15, 24.04)",
+        "id": "commonwealth:z603vv44b"
+    },
+    {
+        "bbox": "ENVELOPE(-76.2, -75.6, 37.25, 36.83)",
+        "id": "commonwealth:z603vs75x"
+    },
+    {
+        "bbox": "ENVELOPE(-71.9, -71.1, 42.0, 41.2)",
+        "id": "commonwealth:cj82m781b"
+    },
+    {
+        "bbox": "ENVELOPE(-66.1632, -65.53, 45.1731, 45.0622)",
+        "id": "commonwealth:9g54xk617"
+    },
+    {
+        "bbox": "ENVELOPE(-75.453611, -75.399722, 44.780556, 44.725)",
+        "id": "commonwealth:hx11z140m"
+    },
+    {
+        "bbox": "ENVELOPE(-73.783333, -73.666667, 41.033333, 40.933333)",
+        "id": "commonwealth:p8418t845"
+    },
+    {
+        "bbox": "ENVELOPE(-70.529167, -70.256944, 47.468056, 47.339167)",
+        "id": "commonwealth:hx11z062f"
+    },
+    {
+        "bbox": "ENVELOPE(-73.983333, -73.65, 41.15, 40.783333)",
+        "id": "commonwealth:p8418t86q"
+    },
+    {
+        "bbox": "ENVELOPE(-80.015555, -79.99944, 40.44583, 40.43666)",
+        "id": "commonwealth:hx11z411s"
+    },
+    {
+        "bbox": "ENVELOPE(-79.243888, -79.23, 40.24416, 40.23555)",
+        "id": "commonwealth:hx11z4033"
+    },
+    {
+        "bbox": "ENVELOPE(-61.4449, -61.311, 45.1337, 45.0417)",
+        "id": "commonwealth:ws859g98t"
+    },
+    {
+        "bbox": "ENVELOPE(-81.344722, -81.2075, 29.9225, 29.65972)",
+        "id": "commonwealth:hx11z477w"
+    },
+    {
+        "bbox": "ENVELOPE(-98.0, -64.0, 47.0, 27.0)",
+        "id": "commonwealth:q524mv18j"
+    },
+    {
+        "bbox": "ENVELOPE(-77.0, -64.0, 47.0, 38.0)",
+        "id": "commonwealth:q524mv20k"
+    },
+    {
+        "bbox": "ENVELOPE(-74.5, -73.55, 41.2, 40.45)",
+        "id": "commonwealth:z603vr75q"
+    },
+    {
+        "bbox": "ENVELOPE(-74.5, -73.55, 41.2, 40.45)",
+        "id": "commonwealth:9s161885z"
+    },
+    {
+        "bbox": "ENVELOPE(-72.80215780443737, -68.27847500673052, 42.707664606200225, 39.751749824061065)",
+        "id": "commonwealth:z603vg396"
+    },
+    {
+        "bbox": "ENVELOPE(-72.03719342331563, -69.50262729496163, 43.10408514620002, 41.2946311123095)",
+        "id": "commonwealth:z603vr778"
+    },
+    {
+        "bbox": "ENVELOPE(-72.5, -70.3, 42.83, 41.5)",
+        "id": "commonwealth:9s1619609"
+    },
+    {
+        "bbox": "ENVELOPE(-74.83333, 40.5, 40.5, 39.5)",
+        "id": "commonwealth:z603vg87v"
+    },
+    {
+        "bbox": "ENVELOPE(-63.584444, -63.576111, 44.649167, 44.644444)",
+        "id": "commonwealth:hx11z040d"
+    },
+    {
+        "bbox": "ENVELOPE(-52.683333, -52.678056, 47.564722, 47.561944)",
+        "id": "commonwealth:6108vv40t"
+    },
+    {
+        "bbox": "ENVELOPE(-52.709722, -52.673889, 47.570833, 47.557222)",
+        "id": "commonwealth:6108vv367"
+    },
+    {
+        "bbox": "ENVELOPE(-75.930556, -75.808889, 44.455556, 44.3675)",
+        "id": "commonwealth:hx11z1026"
+    },
+    {
+        "bbox": "ENVELOPE(-76.5425, -75.429167, 44.733889, 44.072778)",
+        "id": "commonwealth:hx11z104r"
+    },
+    {
+        "bbox": "ENVELOPE(-76.141666, -76.14055, 43.24222, 43.24111)",
+        "id": "commonwealth:hx11z5331"
+    },
+    {
+        "bbox": "ENVELOPE(-80.013333, -80.008889, 40.443056, 40.439444)",
+        "id": "commonwealth:hx11z219k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.594166, -73.57277, 43.27, 43.25222)",
+        "id": "commonwealth:hx11z385c"
+    },
+    {
+        "bbox": "ENVELOPE(-74.008333, -73.883056, 41.333056, 41.2025)",
+        "id": "commonwealth:hx11z2901"
+    },
+    {
+        "bbox": "ENVELOPE(-73.721944, -73.37944, 43.85972, 43.41638)",
+        "id": "commonwealth:hx11z3398"
+    },
+    {
+        "bbox": "ENVELOPE(-79.083333, -76.46666, 43.46666, 43.06666)",
+        "id": "commonwealth:hx11z325x"
+    },
+    {
+        "bbox": "ENVELOPE(-79.083333, -76.483333, 43.466667, 43.166667)",
+        "id": "commonwealth:hx11z130c"
+    },
+    {
+        "bbox": "ENVELOPE(-66.238611, -65.994167, 45.865833, 45.141389)",
+        "id": "commonwealth:hx11z0284"
+    },
+    {
+        "bbox": "ENVELOPE(-74.107778, -74.035278, 40.628333, 40.5675)",
+        "id": "commonwealth:hx11z1646"
+    },
+    {
+        "bbox": "ENVELOPE(-71.079722, -71.034722, 42.394722, 42.363611)",
+        "id": "commonwealth:6108vv481"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0506, -71.0212, 42.234, 42.2148)",
+        "id": "commonwealth:z603vr557"
+    },
+    {
+        "bbox": "ENVELOPE(-71.0506, -71.0212, 42.234, 42.2148)",
+        "id": "commonwealth:x633fb389"
+    },
+    {
+        "bbox": "ENVELOPE(-71.074, -71.043, 42.387, 42.368)",
+        "id": "commonwealth:3f463143r"
+    },
+    {
+        "bbox": "ENVELOPE(-85.883333, -82.2, 36.466667, 34.65)",
+        "id": "commonwealth:hx11z2278"
+    },
+    {
+        "bbox": "ENVELOPE(-74.28, -73.07, 41.07, 40.5)",
+        "id": "commonwealth:6t053q42x"
+    },
+    {
+        "bbox": "ENVELOPE(-73.493889, -73.356389, 43.8575, 43.782778)",
+        "id": "commonwealth:hx11xz54c"
+    },
+    {
+        "bbox": "ENVELOPE(-80.35, -79.8, 32.9, 32.5)",
+        "id": "commonwealth:t722hs85f"
+    },
+    {
+        "bbox": "ENVELOPE(-80.35, -79.8, 32.9, 32.5)",
+        "id": "commonwealth:q524mv135"
+    },
+    {
+        "bbox": "ENVELOPE(-80.35, -79.8, 32.9, 32.5)",
+        "id": "commonwealth:9s161d773"
+    },
+    {
+        "bbox": "ENVELOPE(-73.431389, -73.397778, 44.0425, 44.025)",
+        "id": "commonwealth:hx11z1824"
+    },
+    {
+        "bbox": "ENVELOPE(-77.06, -76.620278, 38.946111, 38.489167)",
+        "id": "commonwealth:hx11z251b"
+    },
+    {
+        "bbox": "ENVELOPE(-79.5849, -79.5216, 32.4912, 32.4439)",
+        "id": "commonwealth:7h149x77p"
+    },
+    {
+        "bbox": "ENVELOPE(-88.116667, -86.966667, 38.716667, 37.75)",
+        "id": "commonwealth:hx11xz58g"
+    },
+    {
+        "bbox": "ENVELOPE(-83.583333, -73.46666, 43.41666, 36.73333)",
+        "id": "commonwealth:hx11z303w"
+    },
+    {
+        "bbox": "ENVELOPE(-91.816667, -89.833333, 31.133333, 29.733333)",
+        "id": "commonwealth:hx11z229t"
+    },
+    {
+        "bbox": "ENVELOPE(-79.85, -73.333333, 45.716667, 42.85)",
+        "id": "commonwealth:hx11z0861"
+    },
+    {
+        "bbox": "ENVELOPE(-60.525, -59.3907, 46.0439, 45.3213)",
+        "id": "commonwealth:7h149w03p"
+    },
+    {
+        "bbox": "ENVELOPE(-63.1314, -62.4213, 46.1854, 45.554)",
+        "id": "commonwealth:7h149v94x"
+    },
+    {
+        "bbox": "ENVELOPE(-74.25, -73.75, 40.75, 40.5)",
+        "id": "commonwealth:q524mt62w"
+    },
+    {
+        "bbox": "ENVELOPE(-74.25, -73.75, 40.75, 40.5)",
+        "id": "commonwealth:q524mt64f"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, -78.0, 36.0, 31.0)",
+        "id": "commonwealth:z603vh758"
+    },
+    {
+        "bbox": "ENVELOPE(-66.17, -65.45, 44.13, 43.19)",
+        "id": "commonwealth:9g54xk731"
+    },
+    {
+        "bbox": "ENVELOPE(-62.381, -62.1947, 44.5544, 44.4653)",
+        "id": "commonwealth:9g54xm30f"
+    },
+    {
+        "bbox": "ENVELOPE(-62.87, -62.62, 17.42, 17.21)",
+        "id": "commonwealth:q524n5268"
+    },
+    {
+        "bbox": "ENVELOPE(-60.5728, -60.4743, 45.3935, 45.3323)",
+        "id": "commonwealth:ws859h08v"
+    },
+    {
+        "bbox": "ENVELOPE(-61.3, -61.1, 13.4, 13.1)",
+        "id": "commonwealth:6t053r22n"
+    },
+    {
+        "bbox": "ENVELOPE(-78.5, -75.0, 39.75, 38.0)",
+        "id": "commonwealth:3f462z95x"
+    },
+    {
+        "bbox": "ENVELOPE(-74.8561729264639, -69.44236522892787, 43.44643486537678, 40.70047206295361)",
+        "id": "commonwealth:x633f942p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5, -69.75, 43.0, 41.0)",
+        "id": "commonwealth:3f462z97g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.86984393830026, -69.37671004622611, 43.34107535350005, 40.75962280131461)",
+        "id": "commonwealth:z603vm77f"
+    },
+    {
+        "bbox": "ENVELOPE(-74.17623067360937, -69.63979353999963, 43.37391513262843, 40.78722693587544)",
+        "id": "commonwealth:wd3765622"
+    },
+    {
+        "bbox": "ENVELOPE(-73.3, -69.85, 43.0, 41.0)",
+        "id": "commonwealth:j38608177"
+    },
+    {
+        "bbox": "ENVELOPE(-72.55, -70.53333, 45.3, 42.68333)",
+        "id": "commonwealth:z603vg442"
+    },
+    {
+        "bbox": "ENVELOPE(-72.55, -70.53333, 45.3, 42.68333)",
+        "id": "commonwealth:z603vg43s"
+    },
+    {
+        "bbox": "ENVELOPE(-72.5, -70.25, 45.25, 42.5)",
+        "id": "commonwealth:3f462z991"
+    },
+    {
+        "bbox": "ENVELOPE(-76.15171909553064, -73.35550676021653, 41.58254911190174, 38.613873615777294)",
+        "id": "commonwealth:z603vg47w"
+    },
+    {
+        "bbox": "ENVELOPE(-76.10786286671473, -73.31947979838226, 41.653459480675, 38.61331931609218)",
+        "id": "commonwealth:z603vq26k"
+    },
+    {
+        "bbox": "ENVELOPE(-76.46272331584733, -73.48091561887013, 41.88916321462845, 38.42420115692579)",
+        "id": "commonwealth:3f4630011"
+    },
+    {
+        "bbox": "ENVELOPE(-80.0, -71.6, 45.1, 40.4)",
+        "id": "commonwealth:3f463003k"
+    },
+    {
+        "bbox": "ENVELOPE(-79.0, -72.0, 45.0, 41.0)",
+        "id": "commonwealth:z603vq44h"
+    },
+    {
+        "bbox": "ENVELOPE(-84.31666, -75.4, 36.58333, 33.75)",
+        "id": "commonwealth:z603vg64j"
+    },
+    {
+        "bbox": "ENVELOPE(-82.1, -75.6, 36.6, 33.5)",
+        "id": "commonwealth:3f463006d"
+    },
+    {
+        "bbox": "ENVELOPE(-80.5, -74.67, 42.33, 39.67)",
+        "id": "commonwealth:6t053q304"
+    },
+    {
+        "bbox": "ENVELOPE(-80.6, -74.4, 42.3, 39.6)",
+        "id": "commonwealth:3f463008z"
+    },
+    {
+        "bbox": "ENVELOPE(-71.9, -71.11666, 42.01666, 41.05)",
+        "id": "commonwealth:z603vg89d"
+    },
+    {
+        "bbox": "ENVELOPE(-71.85, -71.1, 42.05, 41.2)",
+        "id": "commonwealth:3f4630100"
+    },
+    {
+        "bbox": "ENVELOPE(-83.35, -78.48333, 35.2, 32.01666)",
+        "id": "commonwealth:z603vg92q"
+    },
+    {
+        "bbox": "ENVELOPE(-83.5, -78.5, 35.25, 32.0)",
+        "id": "commonwealth:3f463012j"
+    },
+    {
+        "bbox": "ENVELOPE(-83.66666, -75.21666, 39.45, 36.53333)",
+        "id": "commonwealth:z603vh138"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, -75.0, 41.0, 36.0)",
+        "id": "commonwealth:3f463056m"
+    },
+    {
+        "bbox": "ENVELOPE(-83.66666, -75.21666, 39.45, 36.53333)",
+        "id": "commonwealth:z603vh14j"
+    },
+    {
+        "bbox": "ENVELOPE(-96.0, -66.0, 50.0, 29.0)",
+        "id": "commonwealth:z603vq98t"
+    },
+    {
+        "bbox": "ENVELOPE(-79.48333, -75.03333, 39.85, 37.88333)",
+        "id": "commonwealth:z603vg34t"
+    },
+    {
+        "bbox": "ENVELOPE(-79.48333, -75.03333, 39.85, 37.88333)",
+        "id": "commonwealth:z603vg33j"
+    },
+    {
+        "bbox": "ENVELOPE(-61.13, -60.84, 14.16, 13.7)",
+        "id": "commonwealth:q524mt91b"
+    },
+    {
+        "bbox": "ENVELOPE(-75.28027, -74.98527, 40.0475, 39.86694)",
+        "id": "commonwealth:z603vg74s"
+    },
+    {
+        "bbox": "ENVELOPE(-102.0, -77.0, 45.0, 15.0)",
+        "id": "commonwealth:z603vs677"
+    },
+    {
+        "bbox": "ENVELOPE(-59.993611, -59.980833, 45.895833, 45.888056)",
+        "id": "commonwealth:hx11z026k"
+    },
+    {
+        "bbox": "ENVELOPE(-73.5, -73.0, 45.35, 43.0)",
+        "id": "commonwealth:6t053q14r"
+    },
+    {
+        "bbox": "ENVELOPE(-81.5, -81.0, 30.45, 29.25)",
+        "id": "commonwealth:hx11z4717"
+    },
+    {
+        "bbox": "ENVELOPE(-73.415, -73.365833, 43.852778, 43.8275)",
+        "id": "commonwealth:hx11z174f"
+    },
+    {
+        "bbox": "ENVELOPE(-60.85, -60.49, 11.37, 11.13)",
+        "id": "commonwealth:q524mt99j"
+    },
+    {
+        "bbox": "ENVELOPE(-74.15, -71.45, 41.45, 40.5)",
+        "id": "commonwealth:z603vt070"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07, -71.05, 42.38, 42.36)",
+        "id": "commonwealth:dz010v70b"
+    },
+    {
+        "bbox": "ENVELOPE(-81.2529, -80.4857, 32.0725, 31.3659)",
+        "id": "commonwealth:z603vv36n"
+    },
+    {
+        "bbox": "ENVELOPE(-63.131, -62.2147, 46.1854, 45.554)",
+        "id": "commonwealth:7h149v92c"
+    },
+    {
+        "bbox": "ENVELOPE(-71.24, -67.59, 48.41, 46.36)",
+        "id": "commonwealth:7h149v41w"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -33.0, 75.0, 10.0)",
+        "id": "commonwealth:z603vr69k"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -33.0, 75.0, 10.0)",
+        "id": "commonwealth:9s1618557"
+    },
+    {
+        "bbox": "ENVELOPE(-105.0, -33.0, 75.0, 10.0)",
+        "id": "commonwealth:3f462x693"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -51.0, 52.0, 28.0)",
+        "id": "commonwealth:z603vs95d"
+    },
+    {
+        "bbox": "ENVELOPE(-98.0, -58.0, 52.0, 31.0)",
+        "id": "commonwealth:z603vv08g"
+    },
+    {
+        "bbox": "ENVELOPE(-100.0, -50.0, 52.0, 25.0)",
+        "id": "commonwealth:z603vw20z"
+    },
+    {
+        "bbox": "ENVELOPE(-74.021667, -73.9945, 40.726667, 40.7)",
+        "id": "commonwealth:p8418t535"
+    },
+    {
+        "bbox": "ENVELOPE(-76.57386283551186, -76.4554063016092, 37.26617635371527, 37.17017409989066)",
+        "id": "commonwealth:z603vr44q"
+    },
+    {
+        "bbox": "ENVELOPE(-76.531389, -76.486667, 37.253889, 37.22)",
+        "id": "commonwealth:hx11z261k"
+    },
+    {
+        "bbox": "ENVELOPE(-76.55, -73.0, 45.78333, 42.45)",
+        "id": "commonwealth:hx11z319s"
+    },
+    {
+        "bbox": "ENVELOPE(-75.1238, -75.0345, 39.592, 39.5328)",
+        "id": "commonwealth:z603vt15p"
+    },
+    {
+        "bbox": "ENVELOPE(-72.0, -70.41, 42.6, 41.64)",
+        "id": "commonwealth:z603vw10q"
+    },
+    {
+        "bbox": "ENVELOPE(-69.866666, -69.58333, 44.88333, 43.95)",
+        "id": "commonwealth:hx11z309j"
+    },
+    {
+        "bbox": "ENVELOPE(-78.8, -74.6, 41.0, 39.6)",
+        "id": "commonwealth:0r96fq80s"
+    },
+    {
+        "bbox": "ENVELOPE(-73.73, -71.78, 42.05, 40.98)",
+        "id": "commonwealth:z603vt46p"
+    },
+    {
+        "bbox": "ENVELOPE(-63.4041, -63.3007, 44.4403, 44.3554)",
+        "id": "commonwealth:z603vt291"
+    },
+    {
+        "bbox": "ENVELOPE(-95.3, -83.983333, 49.1, 41.083333)",
+        "id": "commonwealth:hx11z3002"
+    },
+    {
+        "bbox": "ENVELOPE(-71.084, -71.049, 42.369, 42.333)",
+        "id": "commonwealth:f4755474m"
+    },
+    {
+        "bbox": "ENVELOPE(-60.86, -60.49, 11.37, 11.13)",
+        "id": "commonwealth:q524n549k"
+    },
+    {
+        "bbox": "ENVELOPE(-60.85, -60.48, 11.38, 11.1)",
+        "id": "commonwealth:6t053r203"
+    },
+    {
+        "bbox": "ENVELOPE(-71.46, -71.15, 41.85, 41.44)",
+        "id": "commonwealth:cj82ks02t"
+    },
+    {
+        "bbox": "ENVELOPE(-71.46, -71.15, 41.85, 41.44)",
+        "id": "commonwealth:3f462w67b"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -73.916667, 40.893333, 40.766667)",
+        "id": "commonwealth:p8418t65z"
+    },
+    {
+        "bbox": "ENVELOPE(-73.95, -73.9, 40.9, 40.8)",
+        "id": "commonwealth:z603vr735"
+    },
+    {
+        "bbox": "ENVELOPE(-73.95, -73.9, 40.9, 40.8)",
+        "id": "commonwealth:9s161881v"
+    },
+    {
+        "bbox": "ENVELOPE(-72.5, -70.0, 45.25, 42.4)",
+        "id": "commonwealth:z603vs65p"
+    },
+    {
+        "bbox": "ENVELOPE(-73.41666, -71.45, 45.0, 42.71666)",
+        "id": "commonwealth:z603vh09p"
+    },
+    {
+        "bbox": "ENVELOPE(-84.0, -76.0, 42.0, 39.0)",
+        "id": "commonwealth:q524mt75z"
+    },
+    {
+        "bbox": "ENVELOPE(-61.233, -61.0957, 45.1559, 45.1011)",
+        "id": "commonwealth:ws859h00n"
+    },
+    {
+        "bbox": "ENVELOPE(-71.07, -71.01, 42.37, 42.33)",
+        "id": "commonwealth:dz010v689"
+    },
+    {
+        "bbox": "ENVELOPE(-95.4, -59.7, 49.38333, 30.35)",
+        "id": "commonwealth:z603vh05k"
+    },
+    {
+        "bbox": "ENVELOPE(-99.0, -65.0, 49.0, 29.0)",
+        "id": "commonwealth:z603vq78b"
+    },
+    {
+        "bbox": "ENVELOPE(-113.22397607830497, -37.206351307654145, 70.4538768733516, 24.16311116794286)",
+        "id": "commonwealth:z603vs502"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -51.0, 52.0, 28.0)",
+        "id": "commonwealth:z603vr84p"
+    },
+    {
+        "bbox": "ENVELOPE(-93.0, -51.0, 52.0, 28.0)",
+        "id": "commonwealth:1257b9296"
+    },
+    {
+        "bbox": "ENVELOPE(-73.64759917270146, -71.23407842730293, 45.19112824789081, 42.50008488684304)",
+        "id": "commonwealth:x059cd58g"
+    },
+    {
+        "bbox": "ENVELOPE(-73.6, -71.3, 45.0, 42.75)",
+        "id": "commonwealth:3f463016n"
+    },
+    {
+        "bbox": "ENVELOPE(-73.43333, -71.45, 45.0, 42.71666)",
+        "id": "commonwealth:z603vh08d"
+    },
+    {
+        "bbox": "ENVELOPE(-65.69, -62.67, 18.6, 17.27)",
+        "id": "commonwealth:q524mt77h"
+    },
+    {
+        "bbox": "ENVELOPE(-71.08, -71.05, 42.38, 42.36)",
+        "id": "commonwealth:dz010v72w"
+    },
+    {
+        "bbox": "ENVELOPE(-83.66666, -75.23333, 39.45, 36.53333)",
+        "id": "commonwealth:z603vh15t"
+    },
+    {
+        "bbox": "ENVELOPE(-74.0, -73.9, 41.9, 41.3)",
+        "id": "commonwealth:z603vt01b"
+    },
+    {
+        "bbox": "ENVELOPE(-105.39211000375492, -40.22876873283771, 36.215017528200015, -0.7376305963084704)",
+        "id": "commonwealth:6t053s02c"
+    },
+    {
+        "bbox": "ENVELOPE(-90.5505602349209, -48.65912574030423, 32.532325421227114, 4.579755910303803)",
+        "id": "commonwealth:z603vh24s"
+    },
+    {
+        "bbox": "ENVELOPE(-108.14181957452674, -57.39061995798514, 29.63566296025995, 2.5008303921720554)",
+        "id": "commonwealth:z603vh252"
+    },
+    {
+        "bbox": "ENVELOPE(-92.61280371082383, -52.300887777545725, 34.56276681052813, 3.533552948974652)",
+        "id": "commonwealth:6t053r88r"
+    },
+    {
+        "bbox": "ENVELOPE(-97.58333, -57.58333, 30.0, 7.0)",
+        "id": "commonwealth:z603vh227"
+    },
+    {
+        "bbox": "ENVELOPE(-116.0, -60.0, 33.0, 5.0)",
+        "id": "commonwealth:0r96fq97z"
+    },
+    {
+        "bbox": "ENVELOPE(-61.1231, -61.0628, 45.1731, 45.113)",
+        "id": "commonwealth:ws859h026"
+    },
+    {
+        "bbox": "ENVELOPE(-62.0916, -61.521, 45.0446, 44.5248)",
+        "id": "commonwealth:ws859g94q"
+    },
+    {
+        "bbox": "ENVELOPE(-75.58333, -67.58333, 25.0, 19.25)",
+        "id": "commonwealth:z603vh295"
+    },
+    {
+        "bbox": "ENVELOPE(-74.15, -73.983333, 41.516667, 41.416667)",
+        "id": "commonwealth:p8418t802"
+    },
+    {
+        "bbox": "ENVELOPE(-86.17657172926295, -70.05037249793416, 27.67418032832605, 18.91705382039352)",
+        "id": "commonwealth:z603vn21s"
+    }
+]

--- a/src/components/Layout/Homepage/Timeline.vue
+++ b/src/components/Layout/Homepage/Timeline.vue
@@ -206,7 +206,7 @@ export default {
 	scroll-behavior: smooth;
 	background-color: #E3EBEF;
 	padding: 30px;
-	border-radius: 15px;
+	border-radius: 16px;
 }
 .timeline-years::-webkit-scrollbar {
 	display: none;

--- a/src/components/Search/SearchMain.vue
+++ b/src/components/Search/SearchMain.vue
@@ -1,10 +1,10 @@
 <template>
   <form @submit.prevent="newQuery" class="mb-5">
-    <label for="default-search" class="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">Search</label>
+    <label for="default-search" class="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
     <div class="relative flex">
       <input v-model="queryString" type="search" id="default-search"
              @keyup="debouncedQuery" @change="debouncedQuery"
-             class="block w-full p-4 text-xl text-gray-900 border border-gray-300 rounded-l bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+             class="block w-full p-4 text-xl text-gray-900 border border-gray-300 rounded-l bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
              autofocus placeholder="Search keywords, locations, people, institutions ..." required>
       <button type="submit" class="p-4 bg-bismark-500 text-white no-underline rounded-r transition-colors duration-200 ease-in-out flex items-center gap-2 hover:bg-bismark-700">
         <span>

--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -1,0 +1,154 @@
+---
+
+---
+
+<section class="py-8">
+    <h2
+        class="not-prose flex justify-between items-end gap-2 heading-underlined font-heading font-medium text-bismark-950 text-xl mb-4 md:text-3xl"
+    >
+        <span>Explore by Map</span>
+    </h2>
+
+    <div class="flex mb-3 bg-gray-100 p-2">
+        <div class="rounded px-2 py-1 bg-bismark-950 text-white mr-4">
+            Filtered by size
+        </div>
+        <span class="rounded px-2 py-1 bg-gray-100 mr-4">Smallest</span>
+        <input
+            type="range"
+            min="1"
+            max="100"
+            value="50"
+            class="slider grow"
+            id="map-slider"
+        />
+        <span class="rounded px-2 py-1 bg-gray-100 ml-4">Largest</span>
+    </div>
+
+    <div id="mapDiv"></div>
+</section>
+
+<script>
+    import Map from "ol/Map.js";
+    import OSM from "ol/source/OSM.js";
+    import TileLayer from "ol/layer/Tile.js";
+    import View from "ol/View.js";
+    import VectorLayer from "ol/layer/Vector.js";
+    import VectorSource from "ol/source/Vector.js";
+    import { Fill, Stroke, Style } from "ol/style.js";
+    import Feature from "ol/Feature";
+    import { fromExtent } from "ol/geom/Polygon";
+    import { transformExtent } from "ol/proj";
+    import { getArea } from "ol/extent";
+
+    import bboxes from "@assets/map-bboxes.json";
+
+    const wkt_transformer = (wkt) => {
+        const clean = wkt
+            .replace("ENVELOPE(", "")
+            .replace(")", "")
+            .split(", ")
+            .map((e) => +e); // janky brittle hard coded transform of WKT encoding, but it works
+        return clean;
+    };
+
+    const transformBbox = (a) => {
+        const a_t = [a[0], a[3], a[1], a[2]]; // WKT uses WENS, while OL uses minx miny maxx maxy
+        const e = transformExtent(a_t, "EPSG:4326", "EPSG:3857");
+        return e;
+    };
+
+    const clean_bboxes = bboxes
+        .map((b) => {
+            return { id: b.id, bbox: wkt_transformer(b.bbox) };
+        })
+        .filter((b) => b.bbox[1] > b.bbox[0] && b.bbox[2] > b.bbox[3]); // check for valid WKT where maxx > minx && maxy > miny
+
+    const feature_bboxes = clean_bboxes.map((b) => {
+        return new Feature({
+            geometry: fromExtent(transformBbox(b.bbox)),
+            collection_identifier: b.id,
+        });
+    });
+
+    const source = new VectorSource();
+
+    const vectorLayer = new VectorLayer({
+        source: source,
+        style: new Style({
+            stroke: new Stroke({
+                color: "blue",
+                width: 1,
+            }),
+            fill: new Fill({
+                color: "rgba(255,255,255,0.1)",
+            }),
+        }),
+    });
+
+    const view = new View();
+
+    const map = new Map({
+        target: "mapDiv",
+        layers: [
+            new TileLayer({
+                source: new OSM(),
+            }),
+            vectorLayer,
+        ],
+        view: view,
+    });
+
+    view.fit(
+        fromExtent(
+            transformExtent(
+                [-105.42, 19.18, -62.53, 50.42],
+                "EPSG:4326",
+                "EPSG:3857",
+            ),
+        ),
+    );
+
+    const slider = document.getElementById("map-slider");
+
+    const scaleMin = Math.log(1000);
+    const scaleMax = Math.log(12000000); // hard coded log scaling, should do better but don't want to import d3
+
+    const areaFilterFunction = (f, v) => {
+        const a = Math.sqrt(getArea(f.getGeometry().getExtent()));
+        const sl = Math.exp(scaleMin + v * ((scaleMax - scaleMin) / 100));
+        return a > sl * 0.8 && a < sl * 1.2;
+    };
+
+    const executeFilter = (v) => {
+        source.clear();
+        const filtered = feature_bboxes.filter((f) => areaFilterFunction(f, v));
+        source.addFeatures(filtered);
+    };
+
+    executeFilter(50);
+
+    slider.oninput = function () {
+        executeFilter(this.value);
+    };
+
+    map.on("click", (e) => {
+        const s = source.getFeaturesAtCoordinate(e.coordinate);
+        if (s.length > 0) {
+            console.log(s.map((d) => d.get("collection_identifier")));
+            // TODO: Instead of writing array to console, pass it to collections
+            window.location.href = `./maps/${s[0].get("collection_identifier")}`;
+        } else {
+            window.alert("No maps where you clicked");
+        }
+    });
+</script>
+
+<style>
+    @import "node_modules/ol/ol.css";
+
+    #mapDiv {
+        width: 100%;
+        height: 500px;
+    }
+</style>

--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -1,5 +1,5 @@
 ---
-
+import 'ol/ol.css';
 ---
 
 <section class="py-8">
@@ -145,8 +145,6 @@
 </script>
 
 <style>
-    @import "node_modules/ol/ol.css";
-
     #mapDiv {
         width: 100%;
         height: 500px;

--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -13,16 +13,14 @@ import 'ol/ol.css';
         <div class="rounded px-2 py-1 bg-bismark-950 text-white mr-4">
             Filtered by size
         </div>
-        <span class="rounded px-2 py-1 bg-gray-100 mr-4">Smallest</span>
-        <input
-            type="range"
-            min="1"
-            max="100"
-            value="50"
-            class="slider grow"
-            id="map-slider"
-        />
-        <span class="rounded px-2 py-1 bg-gray-100 ml-4">Largest</span>
+        <div class="relative flex-grow mb-6">
+            <label for="map-size-slider" class="sr-only">Filter maps by size</label>
+            <input id="map-size-slider" type="range" value="50" min="0" max="100" step="any" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700">
+            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-0 -bottom-6">Buildings and forts</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-1/3 -translate-x-1/2 rtl:translate-x-1/2 -bottom-6">Cities</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-2/3 -translate-x-1/2 rtl:translate-x-1/2 -bottom-6">States and regions</span>
+            <span class="text-sm text-gray-500 dark:text-gray-400 absolute end-0 -bottom-6">Hemisphere</span>
+        </div>
     </div>
 
     <div id="mapDiv"></div>
@@ -41,7 +39,10 @@ import 'ol/ol.css';
     import { transformExtent } from "ol/proj";
     import { getArea } from "ol/extent";
 
+    import { applyStyle } from "ol-mapbox-style";
+
     import bboxes from "@assets/map-bboxes.json";
+import VectorTileLayer from "ol/layer/VectorTile";
 
     const wkt_transformer = (wkt) => {
         const clean = wkt
@@ -86,19 +87,23 @@ import 'ol/ol.css';
         }),
     });
 
+    const baseLayer = new VectorTileLayer({declutter: true});
     const view = new View();
 
     const map = new Map({
         target: "mapDiv",
         layers: [
-            new TileLayer({
-                source: new OSM(),
-            }),
-            vectorLayer,
+            baseLayer,
+            vectorLayer
         ],
         view: view,
     });
 
+    const maptilerKey = 'E7YRymn4x0Im2NxjlLks';
+    const styleJson = `https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerKey}`;
+
+    applyStyle(baseLayer, styleJson);
+    
     view.fit(
         fromExtent(
             transformExtent(
@@ -109,15 +114,16 @@ import 'ol/ol.css';
         ),
     );
 
-    const slider = document.getElementById("map-slider");
+    const slider = document.getElementById("map-size-slider");
 
-    const scaleMin = Math.log(1000);
-    const scaleMax = Math.log(12000000); // hard coded log scaling, should do better but don't want to import d3
+    const areaRange = feature_bboxes.map(f => { return Math.sqrt(getArea(f.getGeometry().getExtent())) } )
+    const scaleMin = Math.log(500) // hard coding this because some are way too small
+    const scaleMax = Math.log(Math.max(...areaRange));
 
     const areaFilterFunction = (f, v) => {
         const a = Math.sqrt(getArea(f.getGeometry().getExtent()));
         const sl = Math.exp(scaleMin + v * ((scaleMax - scaleMin) / 100));
-        return a > sl * 0.8 && a < sl * 1.2;
+        return a > sl * 0.6 && a < sl * 1.4;
     };
 
     const executeFilter = (v) => {

--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -2,155 +2,143 @@
 import 'ol/ol.css';
 ---
 
-<section class="py-8">
-    <h2
-        class="not-prose flex justify-between items-end gap-2 heading-underlined font-heading font-medium text-bismark-950 text-xl mb-4 md:text-3xl"
-    >
-        <span>Explore by Map</span>
-    </h2>
+<section class="mb-12">
+  <h2 class="not-prose flex justify-between items-end gap-2 heading-underlined font-heading font-medium text-bismark-950 text-xl mb-4 md:text-3xl">
+    <span>Explore by Map</span>
+  </h2>
 
-    <div class="flex mb-3 bg-gray-100 p-2">
-        <div class="rounded px-2 py-1 bg-bismark-950 text-white mr-4">
-            Filtered by size
-        </div>
-        <div class="relative flex-grow mb-6">
-            <label for="map-size-slider" class="sr-only">Filter maps by size</label>
-            <input id="map-size-slider" type="range" value="50" min="0" max="100" step="any" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700">
-            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-0 -bottom-6">Buildings and forts</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-1/3 -translate-x-1/2 rtl:translate-x-1/2 -bottom-6">Cities</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400 absolute start-2/3 -translate-x-1/2 rtl:translate-x-1/2 -bottom-6">States and regions</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400 absolute end-0 -bottom-6">Hemisphere</span>
-        </div>
+  <div class="overflow-hidden shadow-lg rounded-2xl">
+    <div class="flex flex-col sm:flex-row bg-gray-100 px-3 py-4">
+      <label class="text-bismark-950 font-bold leading-none mb-2 flex-shrink-0 sm:mr-6" for="map-size-slider" class="sr-only">Filtered by size</label>
+      <div class="flex flex-wrap gap-2 justify-between py-1 relative text-[0.625rem] sm:text-sm text-bismark-950 flex-grow">
+        <input id="map-size-slider" type="range" value="50" min="0" max="100" step="any" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-bismark-500 mb-1">
+        <span class="">Buildings and forts</span>
+        <span class="">Cities</span>
+        <span class="">States and regions</span>
+        <span class="">Hemisphere</span>
+      </div>
     </div>
 
-    <div id="mapDiv"></div>
+    <div id="search-map" class="w-full h-[500px]"></div>
+  </div>
 </section>
 
 <script>
-    import Map from "ol/Map.js";
-    import View from "ol/View.js";
-    import VectorLayer from "ol/layer/Vector.js";
-    import VectorSource from "ol/source/Vector.js";
-    import { Fill, Stroke, Style } from "ol/style.js";
-    import Feature from "ol/Feature";
-    import { fromExtent } from "ol/geom/Polygon";
-    import { transformExtent } from "ol/proj";
-    import { getArea } from "ol/extent";
+  import Map from 'ol/Map.js';
+  import View from 'ol/View.js';
+  import VectorLayer from 'ol/layer/Vector.js';
+  import VectorSource from 'ol/source/Vector.js';
+  import { Fill, Stroke, Style } from 'ol/style.js';
+  import Feature from 'ol/Feature';
+  import { fromExtent } from 'ol/geom/Polygon';
+  import { transformExtent } from 'ol/proj';
+  import { getArea } from 'ol/extent';
+  import { applyStyle } from 'ol-mapbox-style';
+  import bboxes from '@assets/map-bboxes.json';
+  import VectorTileLayer from 'ol/layer/VectorTile';
 
-    import { applyStyle } from "ol-mapbox-style";
+  const wkt_transformer = (wkt) => {
+    const clean = wkt
+      .replace("ENVELOPE(", "")
+      .replace(")", "")
+      .split(", ")
+      .map((e) => +e); // janky brittle hard coded transform of WKT encoding, but it works
+    return clean;
+  };
 
-    import bboxes from "@assets/map-bboxes.json";
-import VectorTileLayer from "ol/layer/VectorTile";
+  const transformBbox = (a) => {
+    const a_t = [a[0], a[3], a[1], a[2]]; // WKT uses WENS, while OL uses minx miny maxx maxy
+    const e = transformExtent(a_t, "EPSG:4326", "EPSG:3857");
+    return e;
+  };
 
-    const wkt_transformer = (wkt) => {
-        const clean = wkt
-            .replace("ENVELOPE(", "")
-            .replace(")", "")
-            .split(", ")
-            .map((e) => +e); // janky brittle hard coded transform of WKT encoding, but it works
-        return clean;
-    };
+  const clean_bboxes = bboxes
+    .map((b) => {
+      return { id: b.id, bbox: wkt_transformer(b.bbox) };
+    })
+    .filter((b) => b.bbox[1] > b.bbox[0] && b.bbox[2] > b.bbox[3]); // check for valid WKT where maxx > minx && maxy > miny
 
-    const transformBbox = (a) => {
-        const a_t = [a[0], a[3], a[1], a[2]]; // WKT uses WENS, while OL uses minx miny maxx maxy
-        const e = transformExtent(a_t, "EPSG:4326", "EPSG:3857");
-        return e;
-    };
-
-    const clean_bboxes = bboxes
-        .map((b) => {
-            return { id: b.id, bbox: wkt_transformer(b.bbox) };
-        })
-        .filter((b) => b.bbox[1] > b.bbox[0] && b.bbox[2] > b.bbox[3]); // check for valid WKT where maxx > minx && maxy > miny
-
-    const feature_bboxes = clean_bboxes.map((b) => {
-        return new Feature({
-            geometry: fromExtent(transformBbox(b.bbox)),
-            collection_identifier: b.id,
-        });
+  const feature_bboxes = clean_bboxes.map((b) => {
+    return new Feature({
+      geometry: fromExtent(transformBbox(b.bbox)),
+      collection_identifier: b.id,
     });
+  });
 
-    const source = new VectorSource();
+  const source = new VectorSource();
 
-    const vectorLayer = new VectorLayer({
-        source: source,
-        style: new Style({
-            stroke: new Stroke({
-                color: "blue",
-                width: 1,
-            }),
-            fill: new Fill({
-                color: "rgba(255,255,255,0.1)",
-            }),
-        }),
-    });
+  const vectorLayer = new VectorLayer({
+    source: source,
+    style: new Style({
+      stroke: new Stroke({
+        color: '#4e798d',
+        width: 1,
+      }),
+      fill: new Fill({
+        color: 'rgba(255,255,255,0.1)',
+      }),
+    }),
+  });
 
-    const baseLayer = new VectorTileLayer({declutter: true});
-    const view = new View();
+  const baseLayer = new VectorTileLayer({declutter: true});
+  const view = new View();
 
-    const map = new Map({
-        target: "mapDiv",
-        layers: [
-            baseLayer,
-            vectorLayer
-        ],
-        view: view,
-    });
+  const map = new Map({
+    target: 'search-map',
+    layers: [
+      baseLayer,
+      vectorLayer
+    ],
+    view: view,
+  });
 
-    const maptilerKey = 'E7YRymn4x0Im2NxjlLks';
-    const styleJson = `https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerKey}`;
+  const maptilerKey = 'E7YRymn4x0Im2NxjlLks';
+  const styleJson = `https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerKey}`;
 
-    applyStyle(baseLayer, styleJson);
-    
-    view.fit(
-        fromExtent(
-            transformExtent(
-                [-105.42, 19.18, -62.53, 50.42],
-                "EPSG:4326",
-                "EPSG:3857",
-            ),
-        ),
-    );
+  applyStyle(baseLayer, styleJson);
+  
+  view.fit(
+    fromExtent(
+      transformExtent(
+        [-105.42, 19.18, -62.53, 50.42],
+        'EPSG:4326',
+        'EPSG:3857',
+      ),
+    ),
+  );
 
-    const slider = document.getElementById("map-size-slider");
+  const slider = document.getElementById('map-size-slider');
 
-    const areaRange = feature_bboxes.map(f => { return Math.sqrt(getArea(f.getGeometry().getExtent())) } )
-    const scaleMin = Math.log(500) // hard coding this because some are way too small
-    const scaleMax = Math.log(Math.max(...areaRange));
+  const areaRange = feature_bboxes.map(f => { return Math.sqrt(getArea(f.getGeometry().getExtent())) } )
+  const scaleMin = Math.log(500) // hard coding this because some are way too small
+  const scaleMax = Math.log(Math.max(...areaRange));
 
-    const areaFilterFunction = (f, v) => {
-        const a = Math.sqrt(getArea(f.getGeometry().getExtent()));
-        const sl = Math.exp(scaleMin + v * ((scaleMax - scaleMin) / 100));
-        return a > sl * 0.6 && a < sl * 1.4;
-    };
+  const areaFilterFunction = (f, v) => {
+    const a = Math.sqrt(getArea(f.getGeometry().getExtent()));
+    const sl = Math.exp(scaleMin + v * ((scaleMax - scaleMin) / 100));
+    return a > sl * 0.6 && a < sl * 1.4;
+  };
 
-    const executeFilter = (v) => {
-        source.clear();
-        const filtered = feature_bboxes.filter((f) => areaFilterFunction(f, v));
-        source.addFeatures(filtered);
-    };
+  const executeFilter = (v) => {
+    source.clear();
+    const filtered = feature_bboxes.filter((f) => areaFilterFunction(f, v));
+    source.addFeatures(filtered);
+  };
 
-    executeFilter(50);
+  executeFilter(50);
 
-    slider.oninput = function () {
-        executeFilter(this.value);
-    };
+  slider.oninput = function () {
+    executeFilter(this.value);
+  };
 
-    map.on("click", (e) => {
-        const s = source.getFeaturesAtCoordinate(e.coordinate);
-        if (s.length > 0) {
-            console.log(s.map((d) => d.get("collection_identifier")));
-            // TODO: Instead of writing array to console, pass it to collections
-            window.location.href = `./maps/${s[0].get("collection_identifier")}`;
-        } else {
-            window.alert("No maps where you clicked");
-        }
-    });
-</script>
-
-<style>
-    #mapDiv {
-        width: 100%;
-        height: 500px;
+  map.on('click', (e) => {
+    const s = source.getFeaturesAtCoordinate(e.coordinate);
+    if (s.length > 0) {
+      console.log(s.map((d) => d.get('collection_identifier')));
+      // TODO: Instead of writing array to console, pass it to collections
+      window.location.href = `./maps/${s[0].get('collection_identifier')}`;
+    } else {
+      window.alert('No maps where you clicked');
     }
-</style>
+  });
+</script>

--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -28,8 +28,6 @@ import 'ol/ol.css';
 
 <script>
     import Map from "ol/Map.js";
-    import OSM from "ol/source/OSM.js";
-    import TileLayer from "ol/layer/Tile.js";
     import View from "ol/View.js";
     import VectorLayer from "ol/layer/Vector.js";
     import VectorSource from "ol/source/Vector.js";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import BaseLayout from "@layouts/BaseLayout.astro";
 import SearchHero from '@components/Layout/Homepage/SearchHero.astro'
 import Timeline from '@components/Layout/Homepage/Timeline.vue'
 import CollectionGrid from "@components/CollectionGrid.astro";
+import SearchByMap from "@components/SearchByMap/SearchByMap.astro"
 
 const title = 'Home';
 const description = 'American Revolutionary Geographies Online (ARGO) is a portal containing thousands of maps from dozens of institutions that bring to life the history and geography of the American Revolutionary War era.'
@@ -26,6 +27,7 @@ const facetIdentifiers = facetEntries.map((entry) => (
   <CollectionGrid className="mb-12" title="Explore by Story" contentType="stories" columns={3} identifiers={storyIdentifiers}, maxCards="3" morePage="/stories/" />
   <CollectionGrid className="mb-12" title="Explore by Theme" contentType="facets" columns={4} identifiers={facetIdentifiers}, maxCards="4" morePage="/facets/" />
   <Timeline data={timelineData.data} client:load />
+  <SearchByMap />
   <CollectionGrid className="mb-12" title="Explore by Empires & Nations" contentType="facetCategories" columns={5} identifiers={['empires-and-nations']}, maxCards="5"  morePage="/facets/empires-and-nations/" />
   <CollectionGrid className="mb-12" title="Explore by Features" contentType="facetCategories" columns={5} identifiers={['features']}, maxCards="5"  morePage="/facets/features/" />
   <CollectionGrid className="mb-12" title="Explore by Languages" contentType="facetCategories" columns={5} identifiers={['languages']}, maxCards="5"  morePage="/facets/languages/" />


### PR DESCRIPTION
Preview: https://deploy-preview-86--argo-astro-dev.netlify.app

@almontg @hkemp2128 @emilyrbowe - This is a first working version of a properly componentized, clean-data map view for the front page. I recognize that it doesn't look or work _exactly_ like the version on ARGO v0, but it's a place to start.

Right now, the slider will (in real time) scrub through the bounding boxes of maps by size. It's (IMO) actually a really cool way of visualizing the coverage area of ARGO collections at various scales. When you click on the map, you'll either get a "no maps here" alert, or you'll be taken to the _first_ map at the filtered view scale where you've clicked. Ultimately this should be changed so that it opens the "Drawer" component with a list of _all_ the maps at the clicked location.

LMK if you think this is viable for the initial switch-over to nARGO. 

An easy todo that I'd like to implement is changing the basemap to something more simple, with fewer modern features like highways and administrative boundaries.

@alexandergknoll After the project team has a chance to weigh in above, feel free to review the code and approve a merge in to `main` as long as you're OK with it. Everything here should be pretty self contained, though there is definitely a bit of ... ahem _idiosyncratic_ ... choices I made about some of the geospatial stuff, which I'll try to improve down the line. On line 139 of `SearchByMap.astro` I have indicated where it should eventually get wired up to the "Drawer" component.