### PR TITLE
Timeline bug fixes

### DIFF
--- a/src/components/Layout/Homepage/Timeline.vue
+++ b/src/components/Layout/Homepage/Timeline.vue
@@ -22,7 +22,7 @@
                 {{ data.timeline_eras[year].era }} &nbsp;
                 <span class="era-years">{{ data.timeline_eras[year].era_start_year }} - {{ data.timeline_eras[year].era_end_year }}</span>
               </div>
-              <img class="era-image rounded w-1/2 mb-2" :src="data.timeline_eras[year].background_image" :alt="data.timeline_eras[year].background_image_alt_tag" loading="lazy" />
+              <img class="era-image rounded aspect-[3] object-cover object-center mb-2" :src="data.timeline_eras[year].background_image" :alt="data.timeline_eras[year].background_image_alt_tag" loading="lazy" />
               <div class="era-text leading-tight" v-html="data.timeline_eras[year].era_description"></div>
             </div>
           </div>

--- a/src/components/Layout/Homepage/Timeline.vue
+++ b/src/components/Layout/Homepage/Timeline.vue
@@ -22,8 +22,8 @@
                 {{ data.timeline_eras[year].era }} &nbsp;
                 <span class="era-years">{{ data.timeline_eras[year].era_start_year }} - {{ data.timeline_eras[year].era_end_year }}</span>
               </div>
-              <img class="era-image" :src="data.timeline_eras[year].background_image" :alt="data.timeline_eras[year].background_image_alt_tag" loading="lazy" />
-              <div class="era-text" v-html="data.timeline_eras[year].era_description"></div>
+              <img class="era-image rounded w-1/2 mb-2" :src="data.timeline_eras[year].background_image" :alt="data.timeline_eras[year].background_image_alt_tag" loading="lazy" />
+              <div class="era-text leading-tight" v-html="data.timeline_eras[year].era_description"></div>
             </div>
           </div>
           <div class="year-text">{{ year }}</div>

--- a/src/content/timeline/timeline.json
+++ b/src/content/timeline/timeline.json
@@ -52,7 +52,7 @@
       "id": "5",
       "era": "Early Republic and Loyalism",
       "era_start_year": "1783",
-      "era_end_year": "1800",
+      "era_end_year": "1798",
       "era_left": "71.6%",
       "era_width": "28.1%",
       "era_description": "<p>American independence was recognized by the British in 1783, once again transforming the political realities of North America. The new United States began the long and often difficult process of determining how the nation should be governed and who it should be governed by. The remaining British territories were flooded by thousands of Loyalist refugees, who also sought to find a new way to live within what they hoped would be a revitalized British Empire. Native peoples, meanwhile, faced a new era of painful challenges, as many nations were forced to accept treaties giving up their lands and faced unprecedented numbers of new settlers arriving in their homelands as the line of European settlement expanded&nbsp;aggressively to the west.</p>",


### PR DESCRIPTION
@hkemp2128 this addresses the first item in issue #78 by reducing the size of the image and tightening up the line height for the text in the card.

@garrettdashnelson the second item in issue #78 was solved by adjusting the `end_date` for Early Republic and Loyalism to 1798 instead of 1800 - do you have any concerns with making that change? 