### PR TITLE
add new AuthorBlock component

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -12,7 +12,7 @@
 }
 
 .heading-underlined > span {
-	@apply pb-2 -mb-[3px];
+	@apply pb-2 -mb-[3px] px-2;
 
   box-shadow: inset 0 1.1em theme("colors.gray.50"),
               inset 0.5px 0 theme("colors.bismark.500"),

--- a/src/components/Layout/AuthorBlock.astro
+++ b/src/components/Layout/AuthorBlock.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+  authorType?: string
+}
+
+const { authorType = "Author" } = Astro.props;
+
+---
+
+<div class="p-2 border-2 border-gray-100 rounded-lg mb-4">
+    <span class="inline-flex items-center uppercase tracking-wide px-2 py-1 text-xs font-medium text-gray-500">{authorType}</span>
+    <span class="inline-flex text-md font-semibold">
+        <slot />
+    </span>
+</div>

--- a/src/pages/stories/[slug].astro
+++ b/src/pages/stories/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from "@layouts/BaseLayout.astro";
 import Title from '@components/Layout/Title.astro';
+import AuthorBlock from '@components/Layout/AuthorBlock.astro';
 
 // Generate a new path for every collection entry
 export async function getStaticPaths() {
@@ -24,7 +25,9 @@ const { Content } = await entry.render();
           <span>{ title }</span>
         </span>
       </Title>
-    <h2> Story by {entry.data.author}</h2>
+    <AuthorBlock>
+      { entry.data.author }
+    </AuthorBlock>
     <Content />
   </article>
   </div>


### PR DESCRIPTION
@almontg @hkemp2128 This adds a simple new "Author Block" for stories, which is more customizable than the hard-coded "Story by" header from before. If you approve (see deploy preview below) I will merge into production.