### PR TITLE
implement basic story_type badges

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -12,7 +12,8 @@
       />
     </div>
     <header class="relative w-full flex flex-grow flex-col items-start px-3 pt-3 pb-4">
-      <h3 v-if="title" class="text-lg leading-tight font-semibold overflow-hidden text-ellipsis text-bismark-900 line-clamp-2">{{title }}</h3>
+      <span v-if="badge" class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-clementine-600/50 mb-2">{{ badge }}</span>
+      <h3 v-if="title" class="text-lg leading-tight font-semibold overflow-hidden text-ellipsis text-bismark-900 line-clamp-2">{{ title }}</h3>
       <p v-if="subtitle" class="text-base leading-tight font-light overflow-hidden text-ellipsis line-clamp-3">{{ subtitle }}</p>
     </header>
     <div class="px-3 pb-3">
@@ -33,6 +34,7 @@ export default {
     'subtitle',
     'link',
     'image',
+    'badge'
   ],
   setup() {
     const loaded = ref(false);

--- a/src/components/Cards/Story.astro
+++ b/src/components/Cards/Story.astro
@@ -15,8 +15,9 @@ const subtitle = entry.data.short_description;
 const linkText = "Read more";
 const linkHref = `/stories/${entry.slug}`;
 const image = entry.data.banner_image;
----
+const story_type = entry.data.story_type ? entry.data.story_type : "Story";
 
+---
 <Card
   client:visible
   className={className}
@@ -27,4 +28,5 @@ const image = entry.data.banner_image;
     text: linkText
   }}
   image={image}
+  badge={story_type}
 />

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -87,6 +87,7 @@ const stories = defineCollection({
         banner_image: z.string().url(),
         author: z.string(),
         publish_date: z.date(),
+        story_type: z.string().optional()
     }),
 });
 

--- a/src/content/stories/forgotten-theater.mdx
+++ b/src/content/stories/forgotten-theater.mdx
@@ -4,6 +4,7 @@ short_description: "Dive into the history of Aquidneck Island, an important tact
 banner_image: "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:q524nd57q/3326,658,3138,1428/,1200/0/default.jpg"
 author: "Paige Duplaise"
 publish_date: 2024-03-02
+story_type: "Interactive"
 ---
 
 <iframe src="https://www.exhibit.so/exhibits/SmDX3j9Bl8e0qRwg4yai?embedded=true" allowfullscreen allow="autoplay" frameborder="0" style="width:80vw; height:70vh"></iframe>

--- a/src/content/stories/mapping-american-revolution-symposium.mdx
+++ b/src/content/stories/mapping-american-revolution-symposium.mdx
@@ -4,6 +4,7 @@ short_description: "Maps relating to the November 2022 Mount Vernon George Washi
 banner_image: "https://a-us.storyblok.com/f/1016535/554x298/28052a9729/mapping_american_revolution.jpg"
 author: "Alexandra Montgomery"
 publish_date: 2024-03-01
+story_type: "Gallery"
 ---
 
 import CollectionGrid from "@components/CollectionGrid.astro"

--- a/src/pages/stories/[slug].astro
+++ b/src/pages/stories/[slug].astro
@@ -14,12 +14,17 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const title = entry.data.title;
+const story_type = entry.data.story_type ? entry.data.story_type : "Story";
 const { Content } = await entry.render();
 
 ---
 <BaseLayout title={title}>
   <div>
     <article class="prose max-w-none">
+      <div class="pb-2">
+        <span class="inline-flex items-center rounded-full bg-gray-50 px-4 py-2 text-lg font-medium text-bismark-600 ring-2 ring-inset ring-clementine-600/20">{ story_type }</span>
+
+      </div>
       <Title>
         <span class="heading-underlined block text-bismark-950">
           <span>{ title }</span>


### PR DESCRIPTION
@almontg @hkemp2128 This implements a basic version of the "Story Type" badges as we discussed on Slack; see deploy preview. The front matter for story content can now include a free text value `story_type`, which I have set for an example as "Interactive" on the Aquidneck Island story and "Gallery" on the MV Symposium story. If the value is not set, it defaults to just "Story."