### PR TITLE
do nothing when clicking on point w no map, plus note about collections

### DIFF
--- a/src/components/SearchByMap/SearchByMap.astro
+++ b/src/components/SearchByMap/SearchByMap.astro
@@ -20,6 +20,9 @@ import 'ol/ol.css';
     </div>
 
     <div id="search-map" class="w-full h-[500px]"></div>
+    <div class="bg-gray-100 px-4 py-2 text-sm text-gray-600 italic">
+      Not all collection records are shown in the Explore by Map view.
+    </div>
   </div>
 </section>
 
@@ -107,10 +110,6 @@ import 'ol/ol.css';
     ],
     view: view,
   });
-
-
-
-
   
   view.fit(
     fromExtent(
@@ -150,8 +149,6 @@ import 'ol/ol.css';
     const s = source.getFeaturesAtCoordinate(e.coordinate);
     if (s.length > 0) {
       window.location.href = `./maps/${s[0].get('collection_identifier')}`;
-    } else {
-      window.alert('No maps where you clicked');
-    }
+    } 
   });
 </script>


### PR DESCRIPTION
@almontg @hkemp2128 This PR does two things:

1. If someone clicks in the "Explore by Map" map where there are no collection bounding boxes, nothing happens (as oppose to throwing a browser alert).
2. There's the following text at the bottom of the "Explore by Map" component: "Not all collection records are shown in the Explore by Map view."