### PR TITLE
metadata on story and people cards

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,20 +1,22 @@
 <template>
-  <div
-    class="card not-prose w-full bg-white shadow-lg rounded-xl flex flex-col justify-start overflow-hidden"
-    :class="className"
-    v-if="loaded"
-  >
+  <div class="card not-prose w-full bg-white shadow-lg rounded-xl flex flex-col justify-start overflow-hidden"
+    :class="className" v-if="loaded">
     <div v-if="image" class="relative w-full aspect-video border-b border-gray-100">
-      <img
-        :src="image"
-        :alt="title"
-        class="absolute z-10 inset-0 w-full h-full object-center object-cover"
-      />
+      <img :src="image" :alt="title" class="absolute z-10 inset-0 w-full h-full object-center object-cover" />
     </div>
     <header class="relative w-full flex flex-grow flex-col items-start px-3 pt-3 pb-4">
-      <span v-if="badge" class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-clementine-600/50 mb-2">{{ badge }}</span>
-      <h3 v-if="title" class="text-lg leading-tight font-semibold overflow-hidden text-ellipsis text-bismark-900 line-clamp-2">{{ title }}</h3>
-      <p v-if="subtitle" class="text-base leading-tight font-light overflow-hidden text-ellipsis line-clamp-3">{{ subtitle }}</p>
+      <div class="flex-col">
+        <span v-for="b in badge"
+          class="inline-flex items-center rounded-full px-2 py-1 mr-2 text-xs font-medium text-gray-600 ring-1 ring-inset ring-clementine-600/50 mb-2">{{
+          b }}</span>
+      </div>
+      <h3 v-if="title"
+        class="text-lg leading-tight font-semibold overflow-hidden text-ellipsis text-bismark-900 line-clamp-2">{{ title
+        }}</h3>
+      <p v-if="subtitle" class="text-base leading-tight font-light overflow-hidden text-ellipsis line-clamp-3">{{
+        subtitle }}</p>
+      <p v-if="meta_line" class="text-base leading-tight italic text-gray-700 my-3">{{
+        meta_line }}</p>
     </header>
     <div class="px-3 pb-3">
       <a class="button dark mt-auto" :href="link.href">{{ link.text }}</a>
@@ -27,14 +29,15 @@
 import { ref } from 'vue';
 
 export default {
-	name: 'Card',
-	props: [
+  name: 'Card',
+  props: [
     'className',
     'title',
     'subtitle',
     'link',
     'image',
-    'badge'
+    'badge',
+    'meta_line'
   ],
   setup() {
     const loaded = ref(false);

--- a/src/components/Cards/Person.astro
+++ b/src/components/Cards/Person.astro
@@ -27,4 +27,6 @@ const image = entry.data.banner_image;
     text: linkText
   }}
   image={image}
+  badge={entry.data.tags}
+  meta_line={entry.data.credit}
 />

--- a/src/components/Cards/Story.astro
+++ b/src/components/Cards/Story.astro
@@ -16,8 +16,18 @@ const linkText = "Read more";
 const linkHref = `/stories/${entry.slug}`;
 const image = entry.data.banner_image;
 const story_type = entry.data.story_type ? entry.data.story_type : "Story";
-
+const meta_line = `${entry.data.author ? entry.data.author + " · " : ""}${
+  entry.data.publish_date
+    ? entry.data.publish_date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        timeZone: 'UTC'
+      })
+    : ""
+}`;
 ---
+
 <Card
   client:visible
   className={className}
@@ -25,8 +35,9 @@ const story_type = entry.data.story_type ? entry.data.story_type : "Story";
   subtitle={subtitle}
   link={{
     href: linkHref,
-    text: linkText
+    text: linkText,
   }}
   image={image}
-  badge={story_type}
+  badge={[story_type]}
+  meta_line={meta_line}
 />


### PR DESCRIPTION
This addresses #151 . @hkemp2128 Note that since this will be the first time we're actually consuming the `publish_date` in the front matter of Stories, I suggest we should go back and update all the Live Talks to the date they were recorded, not the date we published them online.