### PR TITLE
Make timeline a reusable component

### DIFF
--- a/public/content/timeline/timeline.json
+++ b/public/content/timeline/timeline.json
@@ -1,0 +1,2843 @@
+{
+  "timeline_eras": {
+    "1740": {
+      "id": "1",
+      "era": "Growing Tensions",
+      "era_start_year": "1740",
+      "era_end_year": "1756",
+      "era_left": "0",
+      "era_width": "26.5%",
+      "era_description": "<p>The North American colonies of Spain, France, and Britain enjoyed a period of inter-imperial peace lasting from the end of Queen Anne&#39;s War in 1713 until 1739. In that year, a conflict colorfully known as the War of Jenkin&#39;s Ear&nbsp;broke out between Britain and Spain. This war was&nbsp;followed quickly by King George&#39;s War, the American theater of the European War of the Austrian Succession, which brough the French in on the side of the Spanish. Both conflicts concluded in 1748 with an uneasy peace which few observers thought would last. They were correct. This era was marked by rising tensions, military escalation, and fort building as the global superpowers of the age jockeyed for supremacy. Native nations found themselves increasingly forced to choose a side as neutrality became politically untenable.&nbsp;</p>",
+      "background_image": "/content/eras/timeline_events_eras_1_background_image_compress_80.jpg",
+      "background_image_iiif": "",
+      "background_image_alt_tag": ""
+    },
+    "1754": {
+      "id": "2",
+      "era": "Seven Years' War",
+      "era_start_year": "1754",
+      "era_end_year": "1763",
+      "era_left": "23.2%",
+      "era_width": "15%",
+      "era_description": "<p>While the previous years had seen their fair share of inter-imperial conflict, it was nothing in comparison to the massive global conflagration that erupted in the American woods in 1754. In late spring of that year, a very young and inexperienced George Washington wandered into a powder keg on what should have been a routine diplomatic mission protesting the construction of a series of new French forts on the Ohio River. When the smoke cleared, a French officer was dead, and war quickly followed. In 1756 the war spread to Europe and Asia, the first time such a conflict had been initiated in the colonies. After a string of early losses, the British and their Indigenous allies turned the tide in a series of remarkable victories in 1759, which soon became known as the&nbsp;<em>Annus Mirabilis&nbsp;</em>and culminated in the capture of the French colonial capital at Qu&eacute;bec. The Treaty of Paris, signed in early 1763, confirmed the loss of&nbsp;entire French mainland North American empire. All former French claims east of the Mississippi were ceded to the British, with the western territory of Louisiana transferred to the Spanish.</p>",
+      "background_image": "/content/eras/timeline_events_eras_2_background_image_compress_80.jpg",
+      "background_image_iiif": "",
+      "background_image_alt_tag": ""
+    },
+    "1762": {
+      "id": "3",
+      "era": "Imperial Crisis",
+      "era_start_year": "1762",
+      "era_end_year": "1775",
+      "era_left": "36.6%",
+      "era_width": "21.7%",
+      "era_description": "<p>At the end of the Seven Years&#39; War, the British empire in North America had grown to include the entire North American continent east of the Mississippi River. This massive expansion, as well as the many victories of the war and unprecedented levels of colonial-imperial cooperation, initially resulted in a period of trans-Atlantic good feeling and pride. It seemed as though the British empire was primed for an era of success and unity. But this moment was fleeting. Angered by British dismissal and ill-treatment,&nbsp;Native peoples living in the Ohio Country and Great Lakes region rose up before the ink of the global peace treaty was dry. Soon after, the colonial cities of the eastern seaboard erupted in protest and revolt against what they saw as imperial overreach. Meanwhile, the French and Spanish faced their own period of imperial realignment and reform.</p>",
+      "background_image": "/content/eras/timeline_events_eras_3_background_image_compress_80.jpg",
+      "background_image_iiif": "",
+      "background_image_alt_tag": ""
+    },
+    "1775": {
+      "id": "4",
+      "era": "American Revolution",
+      "era_start_year": "1775",
+      "era_end_year": "1783",
+      "era_left": "58.4%",
+      "era_width": "13%",
+      "era_description": "<p>The tensions of the era of Imperial Crisis exploded into full-blown war in April of 1775 at Lexington and Concord. Soon, the continent was riven by civil war as thirteen of Britain&#39;s mainland colonies declared independence.&nbsp;Even where colonies remained loyal in what is now Canada and the Caribbean, battles were fought and individuals pressured to choose sides, particularly after France entered the war on the side of the Americans in 1778.&nbsp;</p>",
+      "background_image": "/content/eras/timeline_events_eras_4_background_image_compress_80.jpg",
+      "background_image_iiif": "",
+      "background_image_alt_tag": ""
+    },
+    "1783": {
+      "id": "5",
+      "era": "Early Republic and Loyalism",
+      "era_start_year": "1783",
+      "era_end_year": "1798",
+      "era_left": "71.6%",
+      "era_width": "28.1%",
+      "era_description": "<p>American independence was recognized by the British in 1783, once again transforming the political realities of North America. The new United States began the long and often difficult process of determining how the nation should be governed and who it should be governed by. The remaining British territories were flooded by thousands of Loyalist refugees, who also sought to find a new way to live within what they hoped would be a revitalized British Empire. Native peoples, meanwhile, faced a new era of painful challenges, as many nations were forced to accept treaties giving up their lands and faced unprecedented numbers of new settlers arriving in their homelands as the line of European settlement expanded&nbsp;aggressively to the west.</p>",
+      "background_image": "/content/eras/timeline_events_eras_5_background_image_compress_80.jpg",
+      "background_image_iiif": "",
+      "background_image_alt_tag": ""
+    }
+  },
+  "timeline_events": {
+    "1739": [
+      {
+        "id": "140",
+        "era": "French-British tensions",
+        "name": "War of Jenkins' Ear",
+        "start_date": "1739-10-22",
+        "end_date": "1748-10-18",
+        "notes": "Largely focused on the Caribbean and northern coast of mainland South America, this largely naval conflict was fought between the British and Spanish abd gad mostly petered out by 1742. It was given its dramatic name for the propaganda role played by Captain Robert Jenkins, who reportedly had his ear cut off by Spanish officials for smuggling.",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1739",
+        "end_year": "1748",
+        "event_date_range": "Oct 22, 1739 - Oct 18, 1748"
+      },
+      {
+        "id": "141",
+        "era": "French-British tensions",
+        "name": "Battle of Porto Bello",
+        "start_date": "1739-11-20",
+        "end_date": null,
+        "notes": "An early success of the War of Jenkins' Ear in which the British, lead by Admiral Edward Vernon (namesake of George Washington's home plantation), captured the Spanish settlement of Portobelo in modern Panama",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1739",
+        "end_year": "",
+        "event_date_range": "Nov 20, 1739"
+      }
+    ],
+    "1740": [
+      {
+        "id": "143",
+        "era": "French-British tensions",
+        "name": "Siege of St Augustine",
+        "start_date": "1740-06-13",
+        "end_date": "1740-07-20",
+        "notes": "As part of the wider Anglo-Spanish conflict, Governor James Oglethorpe of Georgia attacked the Spanish town and fort of St Augustine in modern Florida. While the siege was maintained for over a month and Oglethorpe took many outlying settlements—including the free Black community at Fort Mose—he was eventually forced to withdraw.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1740",
+        "end_year": "1740",
+        "event_date_range": "Jun 13, 1740 - Jul 20, 1740"
+      }
+    ],
+    "1741": [
+      {
+        "id": "145",
+        "era": "French-British tensions",
+        "name": "New York Conspiracy of 1741",
+        "start_date": "1741-01-01",
+        "end_date": null,
+        "notes": "A purported plot by enslaved people and poor whites to burn down New York City. While it is unclear if any such plot actually existed, the reaction was swift and brutal: 172 people were arrested, 84 were transported to the Caribbean and 34 were executed by hanging and burning at the stake. While white men and women were among those arrested and executed, the majority of those put to death were Black men.",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1741",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1741"
+      },
+      {
+        "id": "142",
+        "era": "French-British tensions",
+        "name": "Battle of Cartagena de Indias",
+        "start_date": "1741-03-13",
+        "end_date": "1741-05-20",
+        "notes": "After two previous efforts to sieze the Spanish port (modern day Cartagena, Colombia) failed, Admiral Vernon launched a third effort in spring of 1741 as a combined land and naval assault. However, the end result was a disaster, as a combination of military failures and raging yellow fever decimated British forces and served only to reinforce Spanish supremacy in the region.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1741",
+        "end_year": "1741",
+        "event_date_range": "Mar 13, 1741 - May 20, 1741"
+      },
+      {
+        "id": "146",
+        "era": "French-British tensions",
+        "name": "Russian Exploration of Alaska",
+        "start_date": "1741-07-15",
+        "end_date": null,
+        "notes": "The first Russians make landfall in Alaska.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1741",
+        "end_year": "",
+        "event_date_range": "Jul 15, 1741"
+      }
+    ],
+    "1742": [
+      {
+        "id": "147",
+        "era": "French-British tensions",
+        "name": "Battle of Bloody Marsh",
+        "start_date": "1742-07-07",
+        "end_date": null,
+        "notes": "Governor James Oglethorpe of Georgia successfully repels a Spanish attempt to invade Georgia",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1742",
+        "end_year": "",
+        "event_date_range": "Jul 7, 1742"
+      }
+    ],
+    "1744": [
+      {
+        "id": "139",
+        "era": "French-British tensions",
+        "name": "King George's War",
+        "start_date": "1744-03-01",
+        "end_date": "1748-10-18",
+        "notes": "The American theater of the longer War of the Austrian Succession (1740-1748) pitted the French and British Colonies against each other for the first time since Queen Anne's War, which ended in 1713. While formally two separate wars, particularly in the Caribbean it was an extension of the earlier War of Jenkins' Ear",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1744",
+        "end_year": "1748",
+        "event_date_range": "Mar 1, 1744 - Oct 18, 1748"
+      },
+      {
+        "id": "148",
+        "era": "French-British tensions",
+        "name": "Treaty of Lancaster",
+        "start_date": "1744-06-22",
+        "end_date": "1744-07-04",
+        "notes": "Representatives from the Six Nations Haudenosaunee met with delegates from Pennsylvania, Maryland, and Virginia in Lancaster, PA. The Haudenosaunee agreed to sell their lands in the Shenandoah Valley and reaffirmed friendship with the British colonies",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1744",
+        "end_year": "1744",
+        "event_date_range": "Jun 22, 1744 - Jul 4, 1744"
+      }
+    ],
+    "1745": [
+      {
+        "id": "144",
+        "era": "French-British tensions",
+        "name": "Siege of Louisbourg",
+        "start_date": "1745-05-12",
+        "end_date": "1745-06-28",
+        "notes": "Louisbourg was a French fortress perched in a strategic position controlling access to the Gulf of St Lawrence and widely understood the be the \"key\" to French control of both the region and access to its larger settlements in Quebec. While popularly considered impregnable, it was seized during King George's War by a force largely organized by New Englanders with support from a British Naval fleet. A major propaganda victory for colonists, it was marred by camp fever which raged through the garrison and further undermined when the fort was returned to the French in 1748.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1745",
+        "end_year": "1745",
+        "event_date_range": "May 12, 1745 - Jun 28, 1745",
+        "solr_ids_array": [
+          "commonwealth:hx11z513j",
+          "commonwealth:hx11z5153",
+          "commonwealth:hx11z020x"
+        ]
+      }
+    ],
+    "1746": [
+      {
+        "id": "149",
+        "era": "French-British tensions",
+        "name": "Search of for the Northwest Passage",
+        "start_date": "1746-05-01",
+        "end_date": "1747-10-14",
+        "notes": "Henry Ellis, later governor of Nova Scotia and Georgia, joined efforts to find the fabled Northwest Passage by which ships could cross from Atlantic to Pacific by an arctic route. He was unsuccessful.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1746",
+        "end_year": "1747",
+        "event_date_range": "May 1, 1746 - Oct 14, 1747"
+      }
+    ],
+    "1748": [
+      {
+        "id": "138",
+        "era": "French-British tensions",
+        "name": "Refortification of Louisbourg",
+        "start_date": "1748-01-01",
+        "end_date": null,
+        "notes": "Louisbourg was captured by a force of New Englanders in 1745, but returned to the French after the treaty of Aix-la-Chapelle. Largely dismantled by the British, the French now undertook an ambitious (and never fully realized) refortification effort, signalling their renewed interest in the region.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1748",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1748"
+      },
+      {
+        "id": "1",
+        "era": "French-British tensions",
+        "name": "Treaty of Aix-la-Chapelle",
+        "start_date": "1748-04-24",
+        "end_date": null,
+        "notes": "This treaty formally ended the War of the Austrian Succession (1740-1748, also known as King George's War in North America) between the British and French; however, it left underlying tensions unresolved, and most observers believed that another war was simply a matter of when, not if.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1748",
+        "end_year": "",
+        "event_date_range": "Apr 24, 1748"
+      }
+    ],
+    "1749": [
+      {
+        "id": "2",
+        "era": "French-British tensions",
+        "name": "Foundation of Halifax",
+        "start_date": "1749-06-21",
+        "end_date": null,
+        "notes": "Under the direct orders of the British Parliament, the colony of Nova Scotia is given a civil government for the first time and a new captial, Halifax, is founded on the Atlantic shore. Although the British had claimed the region since 1710, there had been almost no practical British presence on the ground. This action contributed to growing tensions with the French (who still claimed much of the region) as well as the Indigenous nations of the area. ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1749",
+        "end_year": "",
+        "event_date_range": "Jun 21, 1749",
+        "solr_ids_array": [
+          "commonwealth:z603vh430",
+          "commonwealth:hx11z504k"
+        ]
+      }
+    ],
+    "1754": [
+      {
+        "id": "6",
+        "era": "Seven Years War",
+        "name": "Jumonville Affair",
+        "start_date": "1754-05-28",
+        "end_date": null,
+        "notes": "A young George Washington's attempt to deliver a message to the French in the Ohio Country warning them to leave ends in the first armed conflict of what would become the Seven Years' War",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1754",
+        "end_year": "",
+        "event_date_range": "May 28, 1754"
+      },
+      {
+        "id": "7",
+        "era": "Seven Years War",
+        "name": "Battle of Fort Necessity",
+        "start_date": "1754-07-03",
+        "end_date": null,
+        "notes": "George Washington, in retreat after the Jumonville disaster, is attacked by French and Native American forces and suffers and embarassing defeat",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1754",
+        "end_year": "",
+        "event_date_range": "Jul 3, 1754"
+      }
+    ],
+    "1755": [
+      {
+        "id": "26",
+        "era": "Seven Years War",
+        "name": "Acadian Deportation",
+        "start_date": "1755-01-01",
+        "end_date": "1763-01-01",
+        "notes": "The French settler population of what is now the Canadian provinces of Nova Scotia, PEI, and New Brunswick were forcibly removed by the British, sending them into exile in the British Colonies, other French possessions, and France itself.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1755",
+        "end_year": "1763",
+        "event_date_range": "Jan 1, 1755 - Jan 1, 1763",
+        "solr_ids_array": [
+          "commonwealth:dz010v04r"
+        ]
+      },
+      {
+        "id": "8",
+        "era": "Seven Years War",
+        "name": "Braddock Expedition / Battle of Monongahela",
+        "start_date": "1755-05-29",
+        "end_date": "1755-07-09",
+        "notes": "British General Edward Braddock, accompanied by George Washington, sets out from Fort Cumberland with the goal of capturing Fort Duquesne. The force spent a great deal of time cutting a road through the dense forest land and was ultimately ambushed by French and Native American forces after crossing the Monongahela on 9 Jul. Braddock was roundly defeated and suffered massive losses, and he himself died of his wounds during the retreat on 13 Jul.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1755",
+        "end_year": "1755",
+        "event_date_range": "May 29, 1755 - Jul 9, 1755",
+        "solr_ids_array": [
+          "commonwealth:q524nd94v",
+          "commonwealth:q524nd708"
+        ]
+      },
+      {
+        "id": "9",
+        "era": "Seven Years War",
+        "name": "Battle of Fort Beausejour",
+        "start_date": "1755-06-03",
+        "end_date": "1755-06-16",
+        "notes": "Prior to the declaration of formal war, British and French forces come to blows at what is today the border between the Canadian provinces of Nova Scotia and New Brunswick, ending in a British victory and leading directly to the deportation of the French settler Acadian population",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1755",
+        "end_year": "1755",
+        "event_date_range": "Jun 3, 1755 - Jun 16, 1755",
+        "solr_ids_array": [
+          "commonwealth:hx11z5039",
+          "commonwealth:z603vr96g",
+          "commonwealth:6t053n859",
+          "commonwealth:z603vt134",
+          "commonwealth:q524mv32c"
+        ]
+      }
+    ],
+    "1756": [
+      {
+        "id": "150",
+        "era": "Seven Years War",
+        "name": "Battle of Fort Bull",
+        "start_date": "1756-03-27",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1756",
+        "end_year": "",
+        "event_date_range": "Mar 27, 1756",
+        "solr_ids_array": [
+          "commonwealth:hx11z321t"
+        ]
+      },
+      {
+        "id": "10",
+        "era": "Seven Years War",
+        "name": "Battle of Fort Oswego",
+        "start_date": "1756-08-10",
+        "end_date": "1756-08-14",
+        "notes": "The French under General Montcalm capture the British fort at Oswego (now New York)",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1756",
+        "end_year": "1756",
+        "event_date_range": "Aug 10, 1756 - Aug 14, 1756",
+        "solr_ids_array": [
+          "commonwealth:hx11z321t",
+          "commonwealth:q524nj26j"
+        ]
+      }
+    ],
+    "1757": [
+      {
+        "id": "11",
+        "era": "Seven Years War",
+        "name": "Siege of Fort William Henry",
+        "start_date": "1757-08-03",
+        "end_date": "1757-08-09",
+        "notes": "After successfully taking British Fort William Henry, French-allied Native American forces attacked the surrendering British forces in a controversial and widely-publicized assault",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1757",
+        "end_year": "1757",
+        "event_date_range": "Aug 3, 1757 - Aug 9, 1757",
+        "solr_ids_array": [
+          "commonwealth:hx11z337q",
+          "commonwealth:q524nj26j"
+        ]
+      }
+    ],
+    "1758": [
+      {
+        "id": "12",
+        "era": "Seven Years War",
+        "name": "Siege of Louisbourg",
+        "start_date": "1758-06-08",
+        "end_date": "1758-07-26",
+        "notes": "British forces under General Wolfe successfully take the important French fortress town of Louisbourg (today located in Cape Breton, Nova Scotia). This victory paves the way for the French defeat at Quebec a few months later, and French loss generally.",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1758",
+        "end_year": "1758",
+        "event_date_range": "Jun 8, 1758 - Jul 26, 1758",
+        "solr_ids_array": [
+          "commonwealth:z603vw128",
+          "commonwealth:hx11z050n"
+        ]
+      },
+      {
+        "id": "13",
+        "era": "Seven Years War",
+        "name": "Battle of Carillon",
+        "start_date": "1758-07-06",
+        "end_date": "1758-07-08",
+        "notes": "A small French and Native American force soundly defeated a significantly larger British army in the bloodiest battle of the Seven Years' War in North America ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1758",
+        "end_year": "1758",
+        "event_date_range": "Jul 6, 1758 - Jul 8, 1758",
+        "solr_ids_array": [
+          "commonwealth:hx11z5374",
+          "commonwealth:hx11z3419",
+          "commonwealth:hx11z337q"
+        ]
+      },
+      {
+        "id": "14",
+        "era": "Seven Years War",
+        "name": "Forbes Expedition",
+        "start_date": "1758-09-01",
+        "end_date": "1758-11-01",
+        "notes": "British forces under General John Forbes and George Washington march into the Ohio country in a renewed effort to capture Fort Duquesne. After several skirmishes with the French, the British arrived at Fort Duquesne on 25 Nov to find that it had been burned by the demoralized French garrison after they had been abandoned by their Indigenous allies.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1758",
+        "end_year": "1758",
+        "event_date_range": "Sep 1, 1758 - Nov 1, 1758"
+      }
+    ],
+    "1759": [
+      {
+        "id": "15",
+        "era": "Seven Years War",
+        "name": "Taking of Guadeloupe",
+        "start_date": "1759-01-22",
+        "end_date": "1759-05-01",
+        "notes": "British forces attack and, eventually, take the French Caribbean island of Guadelope.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1759",
+        "end_year": "1759",
+        "event_date_range": "Jan 22, 1759 - May 1, 1759"
+      },
+      {
+        "id": "151",
+        "era": "Seven Years War",
+        "name": "Skirmish at Fort Oswego",
+        "start_date": "1759-07-05",
+        "end_date": null,
+        "notes": "The British rebuilt a fort at Oswego in 1759 and used it as the staging ground for the Siege of Fort Niagara. Prior to the beginning of the siege, the fort was attacked by a party of French and their Indigenous allies. Some skirmishing ensued but there were limited casualties.",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1759",
+        "end_year": "",
+        "event_date_range": "Jul 5, 1759",
+        "solr_ids_array": [
+          "commonwealth:hx11z123z",
+          "commonwealth:hx11z121d"
+        ]
+      },
+      {
+        "id": "16",
+        "era": "Seven Years War",
+        "name": "Battle of Fort Niagara",
+        "start_date": "1759-07-06",
+        "end_date": "1759-07-26",
+        "notes": "British and Iroquois forces capture the French fort at Niagara. In concert with Wolfe's victory at Quebec, this battle ensured the defeat of the French in Canada.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1759",
+        "end_year": "1759",
+        "event_date_range": "Jul 6, 1759 - Jul 26, 1759"
+      },
+      {
+        "id": "17",
+        "era": "Seven Years War",
+        "name": "Capture of Fort Carillon/Ticonderoga",
+        "start_date": "1759-07-26",
+        "end_date": "1759-07-27",
+        "notes": "A large British force under General Jeffrey Amherst captured Fort Carillon (later renamed Fort Ticonderoga), garrisoned by a paltry 400 French soldiers. ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1759",
+        "end_year": "1759",
+        "event_date_range": "Jul 26, 1759 - Jul 27, 1759"
+      },
+      {
+        "id": "18",
+        "era": "Seven Years War",
+        "name": "Accession of Charles III",
+        "start_date": "1759-08-10",
+        "end_date": null,
+        "notes": "After the death of his half-brother Ferdinand VI, Charles III takes the throne of Spain and begins an era of vigorous imperial reform in response to Spanish losses in the Seven Years' War. ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1759",
+        "end_year": "",
+        "event_date_range": "Aug 10, 1759"
+      },
+      {
+        "id": "19",
+        "era": "Seven Years War",
+        "name": "Battle of the Plains of Abraham",
+        "start_date": "1759-09-13",
+        "end_date": null,
+        "notes": "British General Wolfe defeats French General Montcalm in a dramatic battle at Québec City; both generals die, and French power in North America is irrevocably damaged,",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1759",
+        "end_year": "",
+        "event_date_range": "Sep 13, 1759",
+        "solr_ids_array": [
+          "commonwealth:q524n4661",
+          "commonwealth:hx11xz60h",
+          "commonwealth:x059c9925"
+        ]
+      }
+    ],
+    "1760": [
+      {
+        "id": "20",
+        "era": "Seven Years War",
+        "name": "Tacky's Revolt",
+        "start_date": "1760-04-07",
+        "end_date": "1761-01-01",
+        "notes": "Amidst the chaos of the continuing Seven Years' War, a massive slave uprising led by Fante leader Tacky broke out across Jamaica. Although ultimately repressed, the revolt was the largest slave uprising in the Caribbean prior to the Haitian Revolution.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1760",
+        "end_year": "1761",
+        "event_date_range": "Apr 7, 1760 - Jan 1, 1761"
+      },
+      {
+        "id": "21",
+        "era": "Seven Years War",
+        "name": "Accession of George III",
+        "start_date": "1760-10-25",
+        "end_date": null,
+        "notes": "After the death of his grandfather George II, George III becomes King of Great Britain and Ireland",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1760",
+        "end_year": "",
+        "event_date_range": "Oct 25, 1760"
+      }
+    ],
+    "1761": [
+      {
+        "id": "152",
+        "era": "Seven Years War",
+        "name": "Battle of La Belle-Famille",
+        "start_date": "1761-07-24",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1761",
+        "end_year": "",
+        "event_date_range": "Jul 24, 1761",
+        "solr_ids_array": [
+          "commonwealth:6108vv65p"
+        ]
+      }
+    ],
+    "1762": [
+      {
+        "id": "22",
+        "era": "Seven Years War",
+        "name": "Taking of Martinique",
+        "start_date": "1762-01-05",
+        "end_date": "1762-02-12",
+        "notes": "After trying and failing to take the island in 1759, the British return to the French Caribbean island of Martinique and successfully capture it",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1762",
+        "end_year": "1762",
+        "event_date_range": "Jan 5, 1762 - Feb 12, 1762"
+      },
+      {
+        "id": "23",
+        "era": "Seven Years War",
+        "name": "Siege of Havana",
+        "start_date": "1762-06-06",
+        "end_date": "1762-08-13",
+        "notes": "Following Spain's entry into the Seven Years' War on the side of the French in January 1762, the British attacked the crucial Spanish colony of Cuba. The British besieged the capitol of Havana for months, finally taking the city in August. The city remained under British occupation until it was returned to the Spanish the next year.",
+        "is_geographic_event": "0",
+        "hide": "0",
+        "start_year": "1762",
+        "end_year": "1762",
+        "event_date_range": "Jun 6, 1762 - Aug 13, 1762"
+      },
+      {
+        "id": "27",
+        "era": "Imperial Crisis",
+        "name": "Pontiac's War",
+        "start_date": "1762-04-27",
+        "end_date": "1766-07-25",
+        "notes": "Angered by British policies and concerned about the departure of long-time allies the French, a confederation of western Indigenous nations in the Ohio Country and Great Lakes renew war against the British.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1762",
+        "end_year": "1766",
+        "event_date_range": "Apr 27, 1762 - Jul 25, 1766"
+      }
+    ],
+    "1763": [
+      {
+        "id": "24",
+        "era": "Seven Years War",
+        "name": "Treaty of Paris",
+        "start_date": "1763-02-10",
+        "end_date": null,
+        "notes": "Treaty ending the Seven Years' War. The French were removed from North America, a dramatic shift in the imperial balance of power.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1763",
+        "end_year": "",
+        "event_date_range": "Feb 10, 1763",
+        "solr_ids_array": [
+          "commonwealth:4m90fp515",
+          "commonwealth:z603vt37q",
+          "commonwealth:z603vg531"
+        ]
+      },
+      {
+        "id": "28",
+        "era": "Imperial Crisis",
+        "name": "Royal Proclamation of 1763",
+        "start_date": "1763-10-07",
+        "end_date": null,
+        "notes": "On the heels of the Treaty of Paris some months earlier, the Royal Proclamation announced the creation of two new colonies on mainland North America—East and West Florida—and laid out new governments for the British Ceded Islands, Quebec, the Floridas, and Nova Scotia. Most controversially, the proclamation anncounced a new border, generally known as the Proclamation Line, that would run down the Appalachian Mountains, and forbade new Euramerican settlements beyond it, an effort to prevent further warfare with Indigenous peoples and keep Europeans settlers close to the coasts.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1763",
+        "end_year": "",
+        "event_date_range": "Oct 7, 1763",
+        "solr_ids_array": [
+          "commonwealth:z603vg95j",
+          "commonwealth:z603vg816",
+          "commonwealth:x633f8505",
+          "commonwealth:6t053n752",
+          "commonwealth:z603vg82g"
+        ]
+      },
+      {
+        "id": "29",
+        "era": "Imperial Crisis",
+        "name": "Mason-Dixon Survey",
+        "start_date": "1763-11-01",
+        "end_date": "1767-10-18",
+        "notes": "Charles Mason and Jeremiah Dixon were hired to survey the much-contested boundary line between the colonies of Pennsylvania, Maryland, and Delaware. Today, the so-called Mason-Dixon Line continues to define borders as well as the conventional division between the Northern and Southern states",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1763",
+        "end_year": "1767",
+        "event_date_range": "Nov 1, 1763 - Oct 18, 1767"
+      }
+    ],
+    "1764": [
+      {
+        "id": "41",
+        "era": "Imperial Crisis",
+        "name": "General Survey of North America",
+        "start_date": "1764-01-01",
+        "end_date": "1775-01-01",
+        "notes": "Responding to their greatly expanded empire in the wake of the Seven Years' War, British officials commission a series of highly detailed surveys of North America under Samuel Holland, William Gerard de Brahm, and others ",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1764",
+        "end_year": "1775",
+        "event_date_range": "Jan 1, 1764 - Jan 1, 1775"
+      },
+      {
+        "id": "30",
+        "era": "Imperial Crisis",
+        "name": "Sugar Act",
+        "start_date": "1764-04-05",
+        "end_date": null,
+        "notes": "In an effort to raise tax revenue after the incredibly expensive Seven Years' War, the Sugar Act lowered the duties on molasses (on the books since 1733) but also required strict enforcement",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1764",
+        "end_year": "",
+        "event_date_range": "Apr 5, 1764"
+      }
+    ],
+    "1765": [
+      {
+        "id": "31",
+        "era": "Imperial Crisis",
+        "name": "Stamp Act Crisis",
+        "start_date": "1765-03-22",
+        "end_date": "1766-03-18",
+        "notes": "As part of efforts to raise revenue in the colonies in the wake of the Seven Years' War, the Stamp Act introduced a tax on paper products in the colonies (the stamp acting as proof that the tax had been paid). Seen as an overstep of imperial authority, the act provoked violent and widespread resistence in most American mainland colonies. Though eventually repealled, Parliament continued to claim the right to directly tax and govern colonists.]",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1765",
+        "end_year": "1766",
+        "event_date_range": "Mar 22, 1765 - Mar 18, 1766"
+      }
+    ],
+    "1766": [
+      {
+        "id": "32",
+        "era": "Imperial Crisis",
+        "name": "Declaratory Act",
+        "start_date": "1766-03-18",
+        "end_date": null,
+        "notes": "Accompanying the repeal of the Stamp Act, the Declaratory Act asserted Parliament's right to pass binding laws in the colonies",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1766",
+        "end_year": "",
+        "event_date_range": "Mar 18, 1766"
+      }
+    ],
+    "1767": [
+      {
+        "id": "33",
+        "era": "Imperial Crisis",
+        "name": "Townshend Acts",
+        "start_date": "1767-06-05",
+        "end_date": "1768-07-06",
+        "notes": "Despite the spectacular failure of the Stamp Act, British Parliament continued to try and find a way to successfully tax the colonies. The Townshend Acts introduced new duties on glass, lead, paint, paper, and tea, stridently insisted on the rights of Parliament to tax its American colonies, and introduced new enforcement mechanisms.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1767",
+        "end_year": "1768",
+        "event_date_range": "Jun 5, 1767 - Jul 6, 1768"
+      }
+    ],
+    "1768": [
+      {
+        "id": "34",
+        "era": "Imperial Crisis",
+        "name": "British Troops Arrive in Boston",
+        "start_date": "1768-10-01",
+        "end_date": null,
+        "notes": "In response to protests over Townshend Acts, British troops arrive in Boston.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1768",
+        "end_year": "",
+        "event_date_range": "Oct 1, 1768"
+      }
+    ],
+    "1769": [
+      {
+        "id": "43",
+        "era": "Imperial Crisis",
+        "name": "Creation of St. John's Island (today Prince Edward Island)",
+        "start_date": "1769-01-01",
+        "end_date": null,
+        "notes": "St John's Island, wrested from the French during the Seven Years' War and surveyed by Samuel Holland, is seperated from Nova Scotia and made its own colony. Most of the land is held by aristocratic absentee landlords.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1769",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1769"
+      },
+      {
+        "id": "44",
+        "era": "Imperial Crisis",
+        "name": "First Carib War ",
+        "start_date": "1769-01-01",
+        "end_date": "1773-01-01",
+        "notes": "Alarmed by British encroachments into their lands on St Vincent—ceded to the British by the French following the 1763 Treaty of Paris—Carib people take up arms. The war ended in a stalemate and the creation of borders between British and Carib parts of the island.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1769",
+        "end_year": "1773",
+        "event_date_range": "Jan 1, 1769 - Jan 1, 1773"
+      }
+    ],
+    "1770": [
+      {
+        "id": "35",
+        "era": "Imperial Crisis",
+        "name": "Boston Massacre",
+        "start_date": "1770-03-05",
+        "end_date": null,
+        "notes": "In an environment of rising tensions between Massachusetts and the Imperial apparatus, a crowd of rowdy Bostonians protesting the ill-treatment of a young wigmaker's apprentice by a British soldier is fired upon, killing five. ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1770",
+        "end_year": "",
+        "event_date_range": "Mar 5, 1770"
+      }
+    ],
+    "1773": [
+      {
+        "id": "36",
+        "era": "Imperial Crisis",
+        "name": "Tea Act",
+        "start_date": "1773-05-10",
+        "end_date": null,
+        "notes": "In an effort to address the glut of tea held by the British East India Company and encourage colonists to purchase tea subject to the Townshend duties, this act allowed the BEI several benefits which would allow them to sell their tea at a significant discount in the colonies.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1773",
+        "end_year": "",
+        "event_date_range": "May 10, 1773"
+      },
+      {
+        "id": "37",
+        "era": "Imperial Crisis",
+        "name": "Boston Tea Party",
+        "start_date": "1773-12-16",
+        "end_date": null,
+        "notes": "In various degrees of disguise, a group of colonists snuck onto British ships in Boston and threw crates of tea overboard to protest the Tea Act",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1773",
+        "end_year": "",
+        "event_date_range": "Dec 16, 1773"
+      }
+    ],
+    "1774": [
+      {
+        "id": "38",
+        "era": "Imperial Crisis",
+        "name": "Passage of the Intolerable Acts",
+        "start_date": "1774-03-31",
+        "end_date": "1774-05-20",
+        "notes": "A series of laws passed by British parliament in the wake of the Boston Tea Party, primarily targeting Massachusetts and, among other things, withdrawing the colony's charter and closing the port of Boston",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1774",
+        "end_year": "1774",
+        "event_date_range": "Mar 31, 1774 - May 20, 1774"
+      },
+      {
+        "id": "39",
+        "era": "Imperial Crisis",
+        "name": "Accession of Louis XVI",
+        "start_date": "1774-05-10",
+        "end_date": null,
+        "notes": "After the death of his grandfather, the long-reigning King Louis XV, the Louis XVI, last of the Bourbon monarchs, becomes King of France",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1774",
+        "end_year": "",
+        "event_date_range": "May 10, 1774"
+      },
+      {
+        "id": "40",
+        "era": "Imperial Crisis",
+        "name": "Quebec Act",
+        "start_date": "1774-06-22",
+        "end_date": null,
+        "notes": "Meant to clarify the particulars of British rule in the former French colony of Canada, the Quebec act codified the borders of the colony and added new territory, guarenteed the free practice of Catholicism, and restored French civil law for private matters",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1774",
+        "end_year": "",
+        "event_date_range": "Jun 22, 1774",
+        "solr_ids_array": [
+          "commonwealth:8049g918n"
+        ]
+      }
+    ],
+    "1775": [
+      {
+        "id": "75",
+        "era": "Revolution",
+        "name": "Siege of Boston",
+        "start_date": "1775-04-19",
+        "end_date": "1776-03-17",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1775",
+        "end_year": "1776",
+        "event_date_range": "Apr 19, 1775 - Mar 17, 1776",
+        "solr_ids_array": [
+          "commonwealth:hx11z274n",
+          "commonwealth:6108vw002",
+          "commonwealth:z603vj44g",
+          "commonwealth:dz010v00n",
+          "commonwealth:3f462v984",
+          "commonwealth:z603vw14t",
+          "commonwealth:dz010v689",
+          "commonwealth:3f462w00z",
+          "commonwealth:dz010v582",
+          "commonwealth:z603vj22f",
+          "commonwealth:z603vj240",
+          "commonwealth:x633fb22d",
+          "commonwealth:z603vw10q",
+          "commonwealth:dz010v72w",
+          "commonwealth:6108vv944",
+          "commonwealth:q524mv160",
+          "commonwealth:z603vw16c",
+          "commonwealth:7h149z806",
+          "commonwealth:z603vj01p",
+          "commonwealth:z603vj26j",
+          "commonwealth:dz010v62n",
+          "commonwealth:z603vj42x",
+          "commonwealth:z603vs791",
+          "commonwealth:8336h244p",
+          "commonwealth:hx11xz487",
+          "commonwealth:cj82m1988",
+          "commonwealth:6108vv987",
+          "commonwealth:z603vj50m",
+          "commonwealth:6108vv901",
+          "commonwealth:wd376806b",
+          "commonwealth:dz010v66r",
+          "commonwealth:6108vv96p",
+          "commonwealth:dz010v603",
+          "commonwealth:6108vv92k",
+          "commonwealth:z603vj38b",
+          "commonwealth:3f462w36b",
+          "commonwealth:z603vj40c",
+          "commonwealth:z603vj614",
+          "commonwealth:wd376564m",
+          "commonwealth:z603vr582",
+          "commonwealth:x633fb26h",
+          "commonwealth:z603vj67s",
+          "commonwealth:3f462w352",
+          "commonwealth:wd376804s",
+          "commonwealth:z603vg043",
+          "commonwealth:x633f856t",
+          "commonwealth:3f462w86j",
+          "commonwealth:wd376798v",
+          "commonwealth:z603vg884",
+          "commonwealth:q524mv09k",
+          "commonwealth:z603vj63p",
+          "commonwealth:3f462w83q",
+          "commonwealth:3f462w840",
+          "commonwealth:3f462x23g",
+          "commonwealth:z603vm676",
+          "commonwealth:3f462w573",
+          "commonwealth:t722hs83w",
+          "commonwealth:q524mv224",
+          "commonwealth:q524n418c"
+        ]
+      },
+      {
+        "id": "97",
+        "era": "Revolution",
+        "name": "Battle of Lexington and Concord",
+        "start_date": "1775-04-19",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1775",
+        "end_year": "",
+        "event_date_range": "Apr 19, 1775",
+        "solr_ids_array": [
+          "commonwealth:z603vg86k",
+          "commonwealth:z603vj169"
+        ]
+      },
+      {
+        "id": "78",
+        "era": "Revolution",
+        "name": "Battle of Bunker Hill",
+        "start_date": "1775-06-17",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1775",
+        "end_year": "",
+        "event_date_range": "Jun 17, 1775",
+        "solr_ids_array": [
+          "commonwealth:z603vr557",
+          "commonwealth:z603vj657",
+          "commonwealth:q524nd88q",
+          "commonwealth:z603vj746",
+          "commonwealth:z603vj14r",
+          "commonwealth:dz010v646",
+          "commonwealth:z603vj48k",
+          "commonwealth:p8418t713",
+          "commonwealth:x633fb389",
+          "commonwealth:z603vj20w",
+          "commonwealth:z603vj283",
+          "commonwealth:3f462v941",
+          "commonwealth:dz010t91w",
+          "commonwealth:z603vg396",
+          "commonwealth:9s1619609",
+          "commonwealth:6108vv481",
+          "commonwealth:z603vj10n",
+          "commonwealth:z603vj304",
+          "commonwealth:z603vt60h",
+          "commonwealth:dz010v70b",
+          "commonwealth:z603vr57s",
+          "commonwealth:3f462x251",
+          "commonwealth:wd376807m",
+          "commonwealth:x633fb40b",
+          "commonwealth:st74cw36c",
+          "commonwealth:1j92h0041",
+          "commonwealth:z603vh49n",
+          "commonwealth:x633fb62c",
+          "commonwealth:wd376800p",
+          "commonwealth:3f462x95q",
+          "commonwealth:q524mv224",
+          "commonwealth:q524n418c",
+          "commonwealth:z603vr778"
+        ]
+      },
+      {
+        "id": "104",
+        "era": "Revolution",
+        "name": "Canada Campaign",
+        "start_date": "1775-08-28",
+        "end_date": "1776-10-11",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1775",
+        "end_year": "1776",
+        "event_date_range": "Aug 28, 1775 - Oct 11, 1776",
+        "solr_ids_array": [
+          "commonwealth:q524nj771",
+          "commonwealth:9s161869k",
+          "commonwealth:z603vn23b",
+          "commonwealth:q524n8916",
+          "commonwealth:z603vr71m",
+          "commonwealth:6t053q14r",
+          "commonwealth:z603vr92c",
+          "commonwealth:8049g920p",
+          "commonwealth:q524n7198",
+          "commonwealth:8049g918n"
+        ]
+      },
+      {
+        "id": "45",
+        "era": "Revolution",
+        "name": "Dunmore's Proclamation",
+        "start_date": "1775-11-07",
+        "end_date": null,
+        "notes": "As the American Revolution began to rage, Virginia governor John Murray, 4th Earl of Dunmore, announced that any enslaved persons who ran away from their enslavers and joined the British cause would recieve their freedom. Dunmore was no abolitionist, and the proclamation was meant as an attack on rebel property and morale; however, it led directly to the freedom of many formerly enslaved people and set a precedent that was later expanded to all colonies later in the war.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1775",
+        "end_year": "",
+        "event_date_range": "Nov 7, 1775"
+      },
+      {
+        "id": "153",
+        "era": "Revolution",
+        "name": "Battle of Quebec",
+        "start_date": "1775-12-31",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1775",
+        "end_year": "",
+        "event_date_range": "Dec 31, 1775",
+        "solr_ids_array": [
+          "commonwealth:z603vr92c",
+          "commonwealth:8049g920p",
+          "commonwealth:q524n7198"
+        ]
+      }
+    ],
+    "1776": [
+      {
+        "id": "115",
+        "era": "Revolution",
+        "name": "Battle of Sullivan's Island",
+        "start_date": "1776-06-28",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Jun 28, 1776",
+        "solr_ids_array": [
+          "commonwealth:z603vh85h",
+          "commonwealth:cj82kx135",
+          "commonwealth:q524nc39k",
+          "commonwealth:wd3768494",
+          "commonwealth:dz010v12f",
+          "commonwealth:z603vr65g",
+          "commonwealth:dz010t89v",
+          "commonwealth:q524nc371",
+          "commonwealth:wd3768558",
+          "commonwealth:z603vn329",
+          "commonwealth:z603vs38s",
+          "commonwealth:z603vg841"
+        ]
+      },
+      {
+        "id": "131",
+        "era": "Revolution",
+        "name": "New York Campaign",
+        "start_date": "1776-07-02",
+        "end_date": "1780-06-07",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1776",
+        "end_year": "1780",
+        "event_date_range": "Jul 2, 1776 - Jun 7, 1780",
+        "solr_ids_array": [
+          "commonwealth:z603vr63x",
+          "commonwealth:z603vn400",
+          "commonwealth:wd376853q",
+          "commonwealth:q524n8674",
+          "commonwealth:q524n877c",
+          "commonwealth:q524n871q",
+          "commonwealth:wd3765508",
+          "commonwealth:q524n8738",
+          "commonwealth:p8418t65z",
+          "commonwealth:9s161883d",
+          "commonwealth:z603vv58p",
+          "commonwealth:z603vv564",
+          "commonwealth:q524n915k",
+          "commonwealth:q524nj91v",
+          "commonwealth:q524n9174",
+          "commonwealth:z603vr75q",
+          "commonwealth:wd376839w",
+          "commonwealth:cj82m115h",
+          "commonwealth:7h149z64t",
+          "commonwealth:z603vt508",
+          "commonwealth:wd376843g",
+          "commonwealth:q524n800r",
+          "commonwealth:3f462w91d",
+          "commonwealth:q524n865k",
+          "commonwealth:p8418t43x",
+          "commonwealth:z603vs919",
+          "commonwealth:z603vh537",
+          "commonwealth:cj82m429g",
+          "commonwealth:wd3768515",
+          "commonwealth:q524n857w",
+          "commonwealth:q524nf101",
+          "commonwealth:q524n8631",
+          "commonwealth:q524n861g",
+          "commonwealth:q524nb11p",
+          "commonwealth:6t053q36s",
+          "commonwealth:q524n838p",
+          "commonwealth:q524n965s",
+          "commonwealth:z603vv42s",
+          "commonwealth:9s161885z",
+          "commonwealth:cj82m109c",
+          "commonwealth:q524n987t",
+          "commonwealth:q524n859f",
+          "commonwealth:p8418t41c",
+          "commonwealth:z603vq32q",
+          "commonwealth:6t053q42x",
+          "commonwealth:z603vs260",
+          "commonwealth:z603vw04k",
+          "commonwealth:q524n888w",
+          "commonwealth:dz010v026",
+          "commonwealth:dz010v468",
+          "commonwealth:dz010v40m",
+          "commonwealth:dz010v38k",
+          "commonwealth:wd3768451",
+          "commonwealth:j3860821t"
+        ]
+      },
+      {
+        "id": "46",
+        "era": "Revolution",
+        "name": "Declaration of Independence",
+        "start_date": "1776-07-04",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Jul 4, 1776"
+      },
+      {
+        "id": "98",
+        "era": "Revolution",
+        "name": "Battle of Long Island",
+        "start_date": "1776-08-27",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Aug 27, 1776",
+        "solr_ids_array": [
+          "commonwealth:z603vr75q",
+          "commonwealth:wd376839w",
+          "commonwealth:cj82m115h",
+          "commonwealth:7h149z64t",
+          "commonwealth:z603vv42s",
+          "commonwealth:9s161885z",
+          "commonwealth:cj82m109c",
+          "commonwealth:p8418t41c",
+          "commonwealth:z603vq32q",
+          "commonwealth:6t053q42x",
+          "commonwealth:z603vs260",
+          "commonwealth:z603vw04k",
+          "commonwealth:wd3768451",
+          "commonwealth:j3860821t"
+        ]
+      },
+      {
+        "id": "87",
+        "era": "Revolution",
+        "name": "Capture of New York",
+        "start_date": "1776-09-13",
+        "end_date": "1776-11-14",
+        "notes": "Part of the New York Campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1776",
+        "end_year": "1776",
+        "event_date_range": "Sep 13, 1776 - Nov 14, 1776",
+        "solr_ids_array": [
+          "commonwealth:q524n8674",
+          "commonwealth:q524n877c",
+          "commonwealth:q524n871q",
+          "commonwealth:wd3765508",
+          "commonwealth:q524n8738",
+          "commonwealth:p8418t65z",
+          "commonwealth:9s161883d",
+          "commonwealth:z603vv42s",
+          "commonwealth:cj82m109c",
+          "commonwealth:z603vw04k",
+          "commonwealth:dz010v468",
+          "commonwealth:dz010v40m",
+          "commonwealth:dz010v38k",
+          "commonwealth:wd3768451",
+          "commonwealth:j3860821t"
+        ]
+      },
+      {
+        "id": "84",
+        "era": "Revolution",
+        "name": "Battle of Lake Champlain",
+        "start_date": "1776-10-11",
+        "end_date": "1776-10-13",
+        "notes": "Part of the Canada Campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1776",
+        "end_year": "1776",
+        "event_date_range": "Oct 11, 1776 - Oct 13, 1776",
+        "solr_ids_array": [
+          "commonwealth:q524nj771",
+          "commonwealth:9s161869k",
+          "commonwealth:z603vn23b",
+          "commonwealth:q524n8916",
+          "commonwealth:z603vr71m",
+          "commonwealth:6t053q14r"
+        ]
+      },
+      {
+        "id": "156",
+        "era": "Revolution",
+        "name": "Battle of Pelham",
+        "start_date": "1776-10-18",
+        "end_date": null,
+        "notes": "Part of the New York campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Oct 18, 1776",
+        "solr_ids_array": [
+          "commonwealth:q524n859f",
+          "commonwealth:z603vw04k"
+        ]
+      },
+      {
+        "id": "114",
+        "era": "Revolution",
+        "name": "Battle of White Plains",
+        "start_date": "1776-10-28",
+        "end_date": null,
+        "notes": "Part of New York Campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Oct 28, 1776",
+        "solr_ids_array": [
+          "commonwealth:wd376843g",
+          "commonwealth:q524n800r",
+          "commonwealth:3f462w91d",
+          "commonwealth:q524n865k",
+          "commonwealth:p8418t43x",
+          "commonwealth:z603vs919",
+          "commonwealth:z603vh537",
+          "commonwealth:cj82m429g",
+          "commonwealth:wd3768515",
+          "commonwealth:z603vq32q",
+          "commonwealth:z603vw04k",
+          "commonwealth:q524n888w"
+        ]
+      },
+      {
+        "id": "127",
+        "era": "Revolution",
+        "name": "British Occupation of Newport",
+        "start_date": "1776-12-08",
+        "end_date": "1779-10-01",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1776",
+        "end_year": "1779",
+        "event_date_range": "Dec 8, 1776 - Oct 1, 1779",
+        "solr_ids_array": [
+          "commonwealth:q524nd580",
+          "commonwealth:q524n7775",
+          "commonwealth:q524n779q",
+          "commonwealth:q524nd56f",
+          "commonwealth:q524nf985",
+          "commonwealth:z603vn07z",
+          "commonwealth:q524n775m",
+          "commonwealth:hx11z278r",
+          "commonwealth:hx11z3134",
+          "commonwealth:7h149z229"
+        ]
+      },
+      {
+        "id": "112",
+        "era": "Revolution",
+        "name": "Battle of Trenton",
+        "start_date": "1776-12-26",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1776",
+        "end_year": "",
+        "event_date_range": "Dec 26, 1776",
+        "solr_ids_array": [
+          "commonwealth:q524n989c"
+        ]
+      }
+    ],
+    "1777": [
+      {
+        "id": "133",
+        "era": null,
+        "name": "Saratoga Campaign",
+        "start_date": "1777-06-14",
+        "end_date": "1777-10-17",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1777",
+        "end_year": "1777",
+        "event_date_range": "Jun 14, 1777 - Oct 17, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb61w",
+          "commonwealth:q524n8941",
+          "commonwealth:wd376835s",
+          "commonwealth:z603vr61c",
+          "commonwealth:q524n9085",
+          "commonwealth:hx11z2901",
+          "commonwealth:z603vt01b",
+          "commonwealth:hx11z292k",
+          "commonwealth:z603vv254",
+          "commonwealth:q524nj89t",
+          "commonwealth:z603vs898",
+          "commonwealth:q524nj81m",
+          "commonwealth:q524nj79k",
+          "commonwealth:q524n900z",
+          "commonwealth:z603vs855",
+          "commonwealth:q524n8984",
+          "commonwealth:q524nj85q",
+          "commonwealth:z603vs73c",
+          "commonwealth:3f462x383",
+          "commonwealth:9g54xk88n",
+          "commonwealth:z603vw064",
+          "commonwealth:p8418t756",
+          "commonwealth:q524nj835",
+          "commonwealth:q524n896k",
+          "commonwealth:q524n902h",
+          "commonwealth:q524nj878"
+        ]
+      },
+      {
+        "id": "103",
+        "era": "Revolution",
+        "name": "Battle of Princeton",
+        "start_date": "1777-01-03",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Jan 3, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nf080"
+        ]
+      },
+      {
+        "id": "119",
+        "era": "Revolution",
+        "name": "Danbury Expedition",
+        "start_date": "1777-04-25",
+        "end_date": "1777-04-28",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1777",
+        "end_year": "1777",
+        "event_date_range": "Apr 25, 1777 - Apr 28, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524n790q"
+        ]
+      },
+      {
+        "id": "132",
+        "era": "Revolution",
+        "name": "Philadelphia Campaign",
+        "start_date": "1777-06-06",
+        "end_date": "1778-06-28",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1777",
+        "end_year": "1778",
+        "event_date_range": "Jun 6, 1777 - Jun 28, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524nd53m",
+          "commonwealth:q524nb49m",
+          "commonwealth:9s161d63r",
+          "commonwealth:q524nb55r",
+          "commonwealth:q524nb72d",
+          "commonwealth:q524nb472",
+          "commonwealth:q524nd733",
+          "commonwealth:q524nk57r",
+          "commonwealth:q524nb51n",
+          "commonwealth:z603vs103",
+          "commonwealth:6w924q121",
+          "commonwealth:q524nb536",
+          "commonwealth:q524nb63f",
+          "commonwealth:q524nb650",
+          "commonwealth:z603vs22w",
+          "commonwealth:z603vv54k",
+          "commonwealth:q524nb05j",
+          "commonwealth:z603vw18x",
+          "commonwealth:q524nb073",
+          "commonwealth:q524nd601",
+          "commonwealth:q524nb09n",
+          "commonwealth:p8418t59t",
+          "commonwealth:z603vn38z",
+          "commonwealth:9s1618778",
+          "commonwealth:z603vr425",
+          "commonwealth:q524nb67j",
+          "commonwealth:q524nb358",
+          "commonwealth:q524nb693",
+          "commonwealth:q524nb579",
+          "commonwealth:z603vs69s",
+          "commonwealth:q524nb59v",
+          "commonwealth:q524n807p",
+          "commonwealth:9s161d49x",
+          "commonwealth:q524mv11m",
+          "commonwealth:q524nk556",
+          "commonwealth:z603vq54r",
+          "commonwealth:6w924q14k",
+          "commonwealth:q524nb37t",
+          "commonwealth:q524nk19b",
+          "commonwealth:z603vs12n",
+          "commonwealth:q524nb41d",
+          "commonwealth:q524nb39c",
+          "commonwealth:z603vn36d",
+          "commonwealth:z603vs189",
+          "commonwealth:z603vv521",
+          "commonwealth:q524nb030",
+          "commonwealth:z603vt03w"
+        ]
+      },
+      {
+        "id": "108",
+        "era": "Revolution",
+        "name": "Battle of Short Hills",
+        "start_date": "1777-06-26",
+        "end_date": null,
+        "notes": "Part of the Philadelphia Campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Jun 26, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb030"
+        ]
+      },
+      {
+        "id": "95",
+        "era": "Revolution",
+        "name": "Battle of Hubbardton",
+        "start_date": "1777-07-07",
+        "end_date": null,
+        "notes": "part of the Saratoga campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Jul 7, 1777",
+        "solr_ids_array": [
+          "commonwealth:3f462x383",
+          "commonwealth:9g54xk88n"
+        ]
+      },
+      {
+        "id": "80",
+        "era": "Revolution",
+        "name": "Battle of Bennington",
+        "start_date": "1777-08-06",
+        "end_date": "1777-08-16",
+        "notes": "Part of the Saratoga campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "1777",
+        "event_date_range": "Aug 6, 1777 - Aug 16, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524n8941",
+          "commonwealth:wd376835s",
+          "commonwealth:z603vr61c"
+        ]
+      },
+      {
+        "id": "74",
+        "era": "Revolution",
+        "name": "Capture of Philadelphia",
+        "start_date": "1777-08-25",
+        "end_date": "1777-11-16",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1777",
+        "end_year": "1777",
+        "event_date_range": "Aug 25, 1777 - Nov 16, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524n803k",
+          "commonwealth:z603vr425",
+          "commonwealth:q524nb67j",
+          "commonwealth:q524nb358",
+          "commonwealth:q524nb693",
+          "commonwealth:q524n807p",
+          "commonwealth:9s161d49x",
+          "commonwealth:q524mv11m",
+          "commonwealth:q524nk556",
+          "commonwealth:z603vq54r",
+          "commonwealth:6w924q14k",
+          "commonwealth:q524nb37t",
+          "commonwealth:q524nk19b",
+          "commonwealth:z603vs12n",
+          "commonwealth:q524nb41d",
+          "commonwealth:q524nb39c",
+          "commonwealth:z603vn36d",
+          "commonwealth:z603vs189"
+        ]
+      },
+      {
+        "id": "82",
+        "era": "Revolution",
+        "name": "Battle of Brandywine",
+        "start_date": "1777-09-11",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Sep 11, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb49m",
+          "commonwealth:9s161d63r",
+          "commonwealth:q524nb55r",
+          "commonwealth:q524nb72d",
+          "commonwealth:q524nb472",
+          "commonwealth:q524nd733",
+          "commonwealth:q524nk57r",
+          "commonwealth:q524nb51n",
+          "commonwealth:z603vs103",
+          "commonwealth:6w924q121",
+          "commonwealth:q524nb536"
+        ]
+      },
+      {
+        "id": "88",
+        "era": "Revolution",
+        "name": "Battle of Freeman's Farm",
+        "start_date": "1777-09-19",
+        "end_date": null,
+        "notes": "Also known as the first battle of Saratoga; part of Saratoga campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Sep 19, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb61w",
+          "commonwealth:q524nj81m",
+          "commonwealth:q524nj79k",
+          "commonwealth:q524n900z",
+          "commonwealth:z603vs855",
+          "commonwealth:q524n896k"
+        ]
+      },
+      {
+        "id": "101",
+        "era": "Revolution",
+        "name": "Battle of Paoli",
+        "start_date": "1777-09-21",
+        "end_date": null,
+        "notes": "Part of Philadelphia campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Sep 21, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb579",
+          "commonwealth:z603vs69s",
+          "commonwealth:q524nb59v"
+        ]
+      },
+      {
+        "id": "90",
+        "era": "Revolution",
+        "name": "Battle of Germantown",
+        "start_date": "1777-10-04",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Oct 4, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524nb63f",
+          "commonwealth:q524nb650",
+          "commonwealth:z603vs22w"
+        ]
+      },
+      {
+        "id": "86",
+        "era": "Revolution",
+        "name": "Battle of Forts Clinton and Montgomery",
+        "start_date": "1777-10-06",
+        "end_date": null,
+        "notes": "Part of the Saratoga campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Oct 6, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524n9085",
+          "commonwealth:hx11z2901",
+          "commonwealth:z603vt01b",
+          "commonwealth:hx11z292k",
+          "commonwealth:z603vv254",
+          "commonwealth:q524nj89t",
+          "commonwealth:z603vs898",
+          "commonwealth:q524nj878"
+        ]
+      },
+      {
+        "id": "89",
+        "era": "Revolution",
+        "name": "Battle of Bemis Heights",
+        "start_date": "1777-10-07",
+        "end_date": null,
+        "notes": "Also known as the second battle of Saratoga and the second battle of Freeman's Farm; part of the Saratoga campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "",
+        "event_date_range": "Oct 7, 1777",
+        "solr_ids_array": [
+          "commonwealth:q524n8984",
+          "commonwealth:q524nj85q",
+          "commonwealth:z603vs73c",
+          "commonwealth:z603vw064",
+          "commonwealth:p8418t756",
+          "commonwealth:q524nj835",
+          "commonwealth:q524n902h"
+        ]
+      },
+      {
+        "id": "113",
+        "era": "Revolution",
+        "name": "Battle of Whitemarsh",
+        "start_date": "1777-12-05",
+        "end_date": "1777-12-07",
+        "notes": "Part of the Philadelphia campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1777",
+        "end_year": "1777",
+        "event_date_range": "Dec 5, 1777 - Dec 7, 1777",
+        "solr_ids_array": [
+          "commonwealth:z603vt03w"
+        ]
+      }
+    ],
+    "1778": [
+      {
+        "id": "126",
+        "era": "Revolution",
+        "name": "Battle of Quinton's Bridge",
+        "start_date": "1778-03-18",
+        "end_date": null,
+        "notes": "Part of the Philadelphia campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Mar 18, 1778",
+        "solr_ids_array": [
+          "commonwealth:z603vv521"
+        ]
+      },
+      {
+        "id": "123",
+        "era": "Revolution",
+        "name": "Battle of Hancock's Bridge",
+        "start_date": "1778-03-21",
+        "end_date": null,
+        "notes": "Part of the Philadelphia campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Mar 21, 1778",
+        "solr_ids_array": [
+          "commonwealth:z603vv54k"
+        ]
+      },
+      {
+        "id": "116",
+        "era": "Revolution",
+        "name": "Battle of Barren Hill",
+        "start_date": "1778-05-20",
+        "end_date": null,
+        "notes": "Part of the Philadelphia campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "May 20, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524nd53m"
+        ]
+      },
+      {
+        "id": "99",
+        "era": "Revolution",
+        "name": "Battle of Monmouth Courthouse",
+        "start_date": "1778-06-28",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Jun 28, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524nb05j",
+          "commonwealth:z603vw18x",
+          "commonwealth:q524nb073",
+          "commonwealth:q524nd601",
+          "commonwealth:q524nb09n",
+          "commonwealth:p8418t59t",
+          "commonwealth:z603vn38z",
+          "commonwealth:9s1618778"
+        ]
+      },
+      {
+        "id": "77",
+        "era": "Revolution",
+        "name": "Battle of Rhode Island",
+        "start_date": "1778-08-29",
+        "end_date": null,
+        "notes": "Part of the British occupation of Newport",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Aug 29, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524nd580",
+          "commonwealth:q524n7775",
+          "commonwealth:q524n779q",
+          "commonwealth:q524nd56f",
+          "commonwealth:q524nf985",
+          "commonwealth:z603vn07z",
+          "commonwealth:7h149z229"
+        ]
+      },
+      {
+        "id": "124",
+        "era": "Revolution",
+        "name": "Battle of Kingsbridge",
+        "start_date": "1778-08-31",
+        "end_date": null,
+        "notes": "Part of the New York campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Aug 31, 1778",
+        "solr_ids_array": [
+          "commonwealth:z603vv58p",
+          "commonwealth:z603vv564"
+        ]
+      },
+      {
+        "id": "120",
+        "era": "Revolution",
+        "name": "Invasion of Dominica",
+        "start_date": "1778-09-07",
+        "end_date": null,
+        "notes": "Part of Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Sep 7, 1778",
+        "solr_ids_array": [
+          "commonwealth:6t053r26r"
+        ]
+      },
+      {
+        "id": "134",
+        "era": "Revolution",
+        "name": "Caribbean Theater",
+        "start_date": "1778-09-07",
+        "end_date": "1781-11-26",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1778",
+        "end_year": "1781",
+        "event_date_range": "Sep 7, 1778 - Nov 26, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vn73j",
+          "commonwealth:6t053r26r",
+          "commonwealth:q524nf31s",
+          "commonwealth:z603vs87q",
+          "commonwealth:dz010v204",
+          "commonwealth:6t053r50t",
+          "commonwealth:6t053r16h",
+          "commonwealth:z603vs324"
+        ]
+      },
+      {
+        "id": "155",
+        "era": "Revolution",
+        "name": "Skirmish Near Tappan",
+        "start_date": "1778-09-27",
+        "end_date": null,
+        "notes": "Part of New York campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Sep 27, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524n987t"
+        ]
+      },
+      {
+        "id": "111",
+        "era": "Revolution",
+        "name": "Invasion of St Lucia",
+        "start_date": "1778-12-18",
+        "end_date": "1778-12-28",
+        "notes": "Part of Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1778",
+        "end_year": "1778",
+        "event_date_range": "Dec 18, 1778 - Dec 28, 1778",
+        "solr_ids_array": [
+          "commonwealth:6t053r16h",
+          "commonwealth:z603vs324"
+        ]
+      },
+      {
+        "id": "106",
+        "era": "Revolution",
+        "name": "Capture of Savannah",
+        "start_date": "1778-12-29",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1778",
+        "end_year": "",
+        "event_date_range": "Dec 29, 1778",
+        "solr_ids_array": [
+          "commonwealth:q524nc64x",
+          "commonwealth:q524nc66g",
+          "commonwealth:6t053p626"
+        ]
+      }
+    ],
+    "1779": [
+      {
+        "id": "96",
+        "era": "Revolution",
+        "name": "Battle of Stony Point",
+        "start_date": "1779-06-16",
+        "end_date": null,
+        "notes": "Part of New York campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1779",
+        "end_year": "",
+        "event_date_range": "Jun 16, 1779",
+        "solr_ids_array": [
+          "commonwealth:q524n915k",
+          "commonwealth:q524nj91v",
+          "commonwealth:q524n9174",
+          "commonwealth:z603vt508"
+        ]
+      },
+      {
+        "id": "102",
+        "era": "Revolution",
+        "name": "Penobscot Expedition",
+        "start_date": "1779-06-17",
+        "end_date": "1779-08-13",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1779",
+        "end_year": "1779",
+        "event_date_range": "Jun 17, 1779 - Aug 13, 1779",
+        "solr_ids_array": [
+          "commonwealth:q524nj240",
+          "commonwealth:z603vr603",
+          "commonwealth:wd3768337"
+        ]
+      },
+      {
+        "id": "154",
+        "era": "Revolution",
+        "name": "Sullivan Expedition",
+        "start_date": "1779-06-18",
+        "end_date": "1779-10-03",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1779",
+        "end_year": "1779",
+        "event_date_range": "Jun 18, 1779 - Oct 3, 1779",
+        "solr_ids_array": [
+          "commonwealth:q524nj42x"
+        ]
+      },
+      {
+        "id": "121",
+        "era": "Revolution",
+        "name": "Siege of Gibraltar",
+        "start_date": "1779-06-24",
+        "end_date": "1783-02-07",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1779",
+        "end_year": "1783",
+        "event_date_range": "Jun 24, 1779 - Feb 7, 1783",
+        "solr_ids_array": [
+          "commonwealth:z603vt82j",
+          "commonwealth:z603vt800",
+          "commonwealth:z603vt843",
+          "commonwealth:z603vh67k",
+          "commonwealth:z603vt886",
+          "commonwealth:dz010v247",
+          "commonwealth:z603vt86n",
+          "commonwealth:dz010v81v",
+          "commonwealth:dz010v26s",
+          "commonwealth:z603vt78z"
+        ]
+      },
+      {
+        "id": "122",
+        "era": "Revolution",
+        "name": "Invasion of Grenada",
+        "start_date": "1779-07-02",
+        "end_date": "1779-07-04",
+        "notes": "Part of Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1779",
+        "end_year": "1779",
+        "event_date_range": "Jul 2, 1779 - Jul 4, 1779",
+        "solr_ids_array": [
+          "commonwealth:q524nf31s"
+        ]
+      },
+      {
+        "id": "107",
+        "era": "Revolution",
+        "name": "Siege of Savannah",
+        "start_date": "1779-09-16",
+        "end_date": "1779-10-19",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1779",
+        "end_year": "1779",
+        "event_date_range": "Sep 16, 1779 - Oct 19, 1779",
+        "solr_ids_array": [
+          "commonwealth:9s161g71v",
+          "commonwealth:q524nc681",
+          "commonwealth:z603vn05d",
+          "commonwealth:hx11z280s",
+          "commonwealth:q524nc72m",
+          "commonwealth:z603vv343",
+          "commonwealth:z603vs20b"
+        ]
+      },
+      {
+        "id": "73",
+        "era": "Revolution",
+        "name": "Battle of San Fernando de Omoa",
+        "start_date": "1779-10-16",
+        "end_date": "1779-11-29",
+        "notes": "Part of Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1779",
+        "end_year": "1779",
+        "event_date_range": "Oct 16, 1779 - Nov 29, 1779",
+        "solr_ids_array": [
+          "commonwealth:z603vs87q"
+        ]
+      }
+    ],
+    "1780": [
+      {
+        "id": "76",
+        "era": null,
+        "name": "Rochambeau's Encampment in Newport",
+        "start_date": "1780-07-11",
+        "end_date": "1780-11-01",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1780",
+        "end_year": "1780",
+        "event_date_range": "Jul 11, 1780 - Nov 1, 1780",
+        "solr_ids_array": [
+          "commonwealth:z603vn07z",
+          "commonwealth:q524n741s",
+          "commonwealth:q524nj32p",
+          "commonwealth:q524n7821",
+          "commonwealth:dz010v48t",
+          "commonwealth:q524n7864",
+          "commonwealth:q524nj304",
+          "commonwealth:q524nj347",
+          "commonwealth:z603vs44x",
+          "commonwealth:z603vn03v"
+        ]
+      },
+      {
+        "id": "85",
+        "era": "Revolution",
+        "name": "Siege of Charleston",
+        "start_date": "1780-03-29",
+        "end_date": "1780-05-12",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1780",
+        "end_year": "1780",
+        "event_date_range": "Mar 29, 1780 - May 12, 1780",
+        "solr_ids_array": [
+          "commonwealth:7h149x77p",
+          "commonwealth:q524nc49t",
+          "commonwealth:q524nc51v",
+          "commonwealth:9s161d773",
+          "commonwealth:q524nc478",
+          "commonwealth:z603vs51b",
+          "commonwealth:q524mv135",
+          "commonwealth:t722hs85f",
+          "commonwealth:z603vs40t",
+          "commonwealth:z603vh384",
+          "commonwealth:dz010v74f",
+          "commonwealth:z603vh85h"
+        ]
+      },
+      {
+        "id": "135",
+        "era": "Revolution",
+        "name": "Southern Campaign",
+        "start_date": "1780-03-29",
+        "end_date": "1782-11-14",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1780",
+        "end_year": "1782",
+        "event_date_range": "Mar 29, 1780 - Nov 14, 1782",
+        "solr_ids_array": [
+          "commonwealth:z603vs83m",
+          "commonwealth:q524nc53d",
+          "commonwealth:q524nc55z",
+          "commonwealth:7h149x77p",
+          "commonwealth:q524nc49t",
+          "commonwealth:q524nc51v",
+          "commonwealth:9s161d773",
+          "commonwealth:q524nc478",
+          "commonwealth:z603vs51b",
+          "commonwealth:q524mv135",
+          "commonwealth:t722hs85f",
+          "commonwealth:z603vs40t",
+          "commonwealth:z603vh384",
+          "commonwealth:q524nc27s",
+          "commonwealth:q524nc29b",
+          "commonwealth:z603vh73q",
+          "commonwealth:z603vs30k",
+          "commonwealth:dz010v74f",
+          "commonwealth:z603vh85h"
+        ]
+      },
+      {
+        "id": "118",
+        "era": "Revolution",
+        "name": "Battle of Connecticut Farms",
+        "start_date": "1780-06-07",
+        "end_date": null,
+        "notes": "Part of New York campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1780",
+        "end_year": "",
+        "event_date_range": "Jun 7, 1780",
+        "solr_ids_array": [
+          "commonwealth:z603vr63x",
+          "commonwealth:z603vn400",
+          "commonwealth:wd376853q"
+        ]
+      },
+      {
+        "id": "83",
+        "era": "Revolution",
+        "name": "Battle of Camden",
+        "start_date": "1780-08-16",
+        "end_date": null,
+        "notes": "Part of Southern Campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1780",
+        "end_year": "",
+        "event_date_range": "Aug 16, 1780",
+        "solr_ids_array": [
+          "commonwealth:z603vs83m",
+          "commonwealth:q524nc53d",
+          "commonwealth:q524nc55z"
+        ]
+      }
+    ],
+    "1781": [
+      {
+        "id": "128",
+        "era": "Revolution",
+        "name": "Skirmish at Richmond",
+        "start_date": "1781-01-05",
+        "end_date": "1781-01-07",
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "1781",
+        "event_date_range": "Jan 5, 1781 - Jan 7, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vv628"
+        ]
+      },
+      {
+        "id": "136",
+        "era": "Revolution",
+        "name": "Yorktown Campaign",
+        "start_date": "1781-01-05",
+        "end_date": "1781-10-18",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1781",
+        "end_year": "1781",
+        "event_date_range": "Jan 5, 1781 - Oct 18, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vv64t",
+          "commonwealth:z603vn11j",
+          "commonwealth:hx11z268h",
+          "commonwealth:hx11z2677",
+          "commonwealth:hx11z265p",
+          "commonwealth:hx11z2634",
+          "commonwealth:z603vs75x",
+          "commonwealth:q524nb960",
+          "commonwealth:z603vv68x",
+          "commonwealth:z603vn42j",
+          "commonwealth:z603vv66c",
+          "commonwealth:z603vv628",
+          "commonwealth:z603vv70z",
+          "commonwealth:q524nc150",
+          "commonwealth:z603vs28j",
+          "commonwealth:hx11z255f",
+          "commonwealth:q524nc257",
+          "commonwealth:q524nc23p",
+          "commonwealth:q524nc193",
+          "commonwealth:hx11z261k",
+          "commonwealth:dz010t968",
+          "commonwealth:q524nk26r",
+          "commonwealth:z603vh77t",
+          "commonwealth:z603vh55s",
+          "commonwealth:z603vn09h",
+          "commonwealth:z603vs53w",
+          "commonwealth:cj82m1172",
+          "commonwealth:q524mv15q",
+          "commonwealth:q524nc214",
+          "commonwealth:q524nf22t",
+          "commonwealth:p8418t63d",
+          "commonwealth:z603vr44q",
+          "commonwealth:hx11xz508",
+          "commonwealth:p8418t55q",
+          "commonwealth:z603vh694",
+          "commonwealth:z603vt64m",
+          "commonwealth:z603vh57b"
+        ]
+      },
+      {
+        "id": "137",
+        "era": "Revolution",
+        "name": "Battle of Cowpens",
+        "start_date": "1781-01-17",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Jan 17, 1781"
+      },
+      {
+        "id": "93",
+        "era": "Revolution",
+        "name": "Battle of Guildford Courthouse",
+        "start_date": "1781-03-15",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Mar 15, 1781",
+        "solr_ids_array": [
+          "commonwealth:q524nc27s",
+          "commonwealth:q524nc29b",
+          "commonwealth:z603vh73q"
+        ]
+      },
+      {
+        "id": "117",
+        "era": "Revolution",
+        "name": "Skirmish at Burwell's Ferry",
+        "start_date": "1781-04-17",
+        "end_date": null,
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Apr 17, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vv64t"
+        ]
+      },
+      {
+        "id": "94",
+        "era": "Revolution",
+        "name": "Battle of Hobkirks Hill",
+        "start_date": "1781-04-25",
+        "end_date": null,
+        "notes": "Part of Southern campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Apr 25, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vs30k"
+        ]
+      },
+      {
+        "id": "125",
+        "era": "Revolution",
+        "name": "Skirmish at Petersburg",
+        "start_date": "1781-04-25",
+        "end_date": null,
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Apr 25, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vn42j",
+          "commonwealth:z603vv66c"
+        ]
+      },
+      {
+        "id": "100",
+        "era": "Revolution",
+        "name": "Action at Osborne's",
+        "start_date": "1781-04-27",
+        "end_date": null,
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Apr 27, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vv68x"
+        ]
+      },
+      {
+        "id": "109",
+        "era": "Revolution",
+        "name": "Battle of Spencer's Ordinary",
+        "start_date": "1781-06-26",
+        "end_date": null,
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Jun 26, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vv70z"
+        ]
+      },
+      {
+        "id": "91",
+        "era": "Revolution",
+        "name": "Battle of Green Spring",
+        "start_date": "1781-07-06",
+        "end_date": null,
+        "notes": "Part of Yorktown campaign",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Jul 6, 1781",
+        "solr_ids_array": [
+          "commonwealth:q524nb960"
+        ]
+      },
+      {
+        "id": "79",
+        "era": "Revolution",
+        "name": "Battle of the Chesapeake",
+        "start_date": "1781-09-05",
+        "end_date": "1781-09-08",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1781",
+        "end_year": "1781",
+        "event_date_range": "Sep 5, 1781 - Sep 8, 1781",
+        "solr_ids_array": [
+          "commonwealth:z603vn11j",
+          "commonwealth:hx11z268h",
+          "commonwealth:hx11z2677",
+          "commonwealth:hx11z265p",
+          "commonwealth:hx11z2634",
+          "commonwealth:z603vs75x"
+        ]
+      },
+      {
+        "id": "92",
+        "era": "Revolution",
+        "name": "Benedict Arnold's Expedition to Connecticut",
+        "start_date": "1781-09-06",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Sep 6, 1781",
+        "solr_ids_array": [
+          "commonwealth:q524n794t"
+        ]
+      },
+      {
+        "id": "72",
+        "era": "Revolution",
+        "name": "Siege of Yorktown",
+        "start_date": "1781-09-28",
+        "end_date": "1781-10-18",
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1781",
+        "end_year": "1781",
+        "event_date_range": "Sep 28, 1781 - Oct 18, 1781",
+        "solr_ids_array": [
+          "commonwealth:q524nc150",
+          "commonwealth:z603vs28j",
+          "commonwealth:hx11z255f",
+          "commonwealth:q524nc257",
+          "commonwealth:q524nc23p",
+          "commonwealth:q524nc193",
+          "commonwealth:hx11z261k",
+          "commonwealth:dz010t968",
+          "commonwealth:q524nk26r",
+          "commonwealth:z603vh77t",
+          "commonwealth:z603vh55s",
+          "commonwealth:z603vn09h",
+          "commonwealth:z603vs53w",
+          "commonwealth:cj82m1172",
+          "commonwealth:q524mv15q",
+          "commonwealth:q524nc214",
+          "commonwealth:q524nf22t",
+          "commonwealth:p8418t63d",
+          "commonwealth:z603vr44q",
+          "commonwealth:hx11xz508",
+          "commonwealth:p8418t55q",
+          "commonwealth:z603vh694",
+          "commonwealth:z603vt64m",
+          "commonwealth:z603vh57b"
+        ]
+      },
+      {
+        "id": "110",
+        "era": "Revolution",
+        "name": "Invasion of St Eustasius",
+        "start_date": "1781-11-26",
+        "end_date": null,
+        "notes": "Part of Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1781",
+        "end_year": "",
+        "event_date_range": "Nov 26, 1781",
+        "solr_ids_array": [
+          "commonwealth:6t053r50t"
+        ]
+      }
+    ],
+    "1782": [
+      {
+        "id": "105",
+        "era": "Revolution",
+        "name": "Battle of the Saintes",
+        "start_date": "1782-04-09",
+        "end_date": "1782-04-12",
+        "notes": "Part of the Caribbean theater",
+        "is_geographic_event": "1",
+        "hide": "1",
+        "start_year": "1782",
+        "end_year": "1782",
+        "event_date_range": "Apr 9, 1782 - Apr 12, 1782",
+        "solr_ids_array": [
+          "commonwealth:dz010v204"
+        ]
+      },
+      {
+        "id": "81",
+        "era": "Revolution",
+        "name": "Battle of Blue Licks",
+        "start_date": "1782-08-19",
+        "end_date": null,
+        "notes": "",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1782",
+        "end_year": "",
+        "event_date_range": "Aug 19, 1782",
+        "solr_ids_array": [
+          "commonwealth:q524n738g"
+        ]
+      }
+    ],
+    "1783": [
+      {
+        "id": "48",
+        "era": "Revolution",
+        "name": "Treaty of Paris (1783)",
+        "start_date": "1783-09-03",
+        "end_date": null,
+        "notes": "This treaty formalled ended conflict between the British and Americans, and recognized the independence of the thirteen colonies who rebelled. Britain ceded its claims to territory between the Appalachian Mountains and the Mississippi River to the new government, and East and West Florida to Spain",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1783",
+        "end_year": "",
+        "event_date_range": "Sep 3, 1783",
+        "solr_ids_array": [
+          "commonwealth:z603vr88s",
+          "commonwealth:w9505s80k",
+          "commonwealth:z603vq747",
+          "commonwealth:q524mt31w",
+          "commonwealth:z603vp98m",
+          "commonwealth:x059cd73k",
+          "commonwealth:6108vv082"
+        ]
+      }
+    ],
+    "1784": [
+      {
+        "id": "66",
+        "era": "Early Republic and Loyalism",
+        "name": "Creation of New Brunswick",
+        "start_date": "1784-01-01",
+        "end_date": null,
+        "notes": "Formerly referred to as mainland Nova Scotia and claimed by the French until the Seven Years' War, in the aftermath of the American Revolution the new colony of New Brunswick is created as a haven for loyalist refugees with hopes to turn it into the \"envy of the American States\"",
+        "is_geographic_event": "1",
+        "hide": "0",
+        "start_year": "1784",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1784",
+        "solr_ids_array": [
+          "commonwealth:hx11z253w"
+        ]
+      }
+    ],
+    "1786": [
+      {
+        "id": "67",
+        "era": "Early Republic and Loyalism",
+        "name": "Northwest Indian War",
+        "start_date": "1786-01-01",
+        "end_date": "1795-01-01",
+        "notes": "While the British ceded lands between the Appalachian Mountains and the Mississippi to the United States in 1783, they did not consult the Native inhabitants of the region. As Anglo-American settlers and state actors expanded into the region, Indigenous Nations pushed back in a series of armed conflicts which included some of the worst defeats ever suffered by the United States army, although the United States was ultimately able to militarily dominate the region. ",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1786",
+        "end_year": "1795",
+        "event_date_range": "Jan 1, 1786 - Jan 1, 1795"
+      },
+      {
+        "id": "50",
+        "era": "Early Republic and Loyalism",
+        "name": "Shays' Rebellion",
+        "start_date": "1786-08-29",
+        "end_date": "1787-02-01",
+        "notes": "Protests against the economic and political policies of the new United States errupted into a armed rebellion in western Massachusetts under Revolutionary war veteran Daniel Shays. This event is considered to be a contributing cause to the widespred sense that a new frame of government—perhaps with a stronger federal component—was needed to replace the Articles of Confederation.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1786",
+        "end_year": "1787",
+        "event_date_range": "Aug 29, 1786 - Feb 1, 1787"
+      }
+    ],
+    "1787": [
+      {
+        "id": "51",
+        "era": "Early Republic and Loyalism",
+        "name": "Constitutional Convention",
+        "start_date": "1787-05-25",
+        "end_date": "1787-09-17",
+        "notes": "Delegates from the American states met in Philadelphia to develop a new frame of government for the nation. The constitution is formally ratified on 21 Jun 1788, and went into effect on 4 Mar 1789.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1787",
+        "end_year": "1787",
+        "event_date_range": "May 25, 1787 - Sep 17, 1787"
+      },
+      {
+        "id": "52",
+        "era": "Early Republic and Loyalism",
+        "name": "Northwest Ordinance",
+        "start_date": "1787-07-13",
+        "end_date": null,
+        "notes": "This act organized the northern lands beyond the Appalachian mountains which were granted to the United States after the Treaty of Paris (1783) into a incorporated territory and laid out the path newly seized lands could take from territory to state. ",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1787",
+        "end_year": "",
+        "event_date_range": "Jul 13, 1787"
+      }
+    ],
+    "1788": [
+      {
+        "id": "53",
+        "era": "Early Republic and Loyalism",
+        "name": "Accession of Charles IV",
+        "start_date": "1788-12-14",
+        "end_date": null,
+        "notes": "Charles IV, a weak monarch later deposed by Napoleon, takes the throne of Spain after the death of his father Charles III.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1788",
+        "end_year": "",
+        "event_date_range": "Dec 14, 1788"
+      }
+    ],
+    "1789": [
+      {
+        "id": "54",
+        "era": "Early Republic and Loyalism",
+        "name": "French Revolution",
+        "start_date": "1789-05-05",
+        "end_date": "1799-11-09",
+        "notes": "The French people rise up in revolt against the Ancien Régime, eventually resulting in the overthrow of the French monarchy and the creation of the first French Republic, with long-ranging consequences for the remaining French colonial holdings in North America as well as the new United States",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1789",
+        "end_year": "1799",
+        "event_date_range": "May 5, 1789 - Nov 9, 1799"
+      }
+    ],
+    "1791": [
+      {
+        "id": "55",
+        "era": "Early Republic and Loyalism",
+        "name": "Vermont admitted as a state",
+        "start_date": "1791-03-04",
+        "end_date": null,
+        "notes": "Vermont is admitted to the union, ending its brief history as the independent Vermont Republic (which was never recognized by the United States)",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1791",
+        "end_year": "",
+        "event_date_range": "Mar 4, 1791"
+      },
+      {
+        "id": "56",
+        "era": "Early Republic and Loyalism",
+        "name": "Pointe Coupée Slave Conspiracy, 1791",
+        "start_date": "1791-07-01",
+        "end_date": null,
+        "notes": "An attempted uprising of enslaved people in Pointe Coupée Parish, Louisiana was thwarted by Spanish officials, leading to a overhaul of the Louisiana slave code meant to encourage \"humane\" treatment.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1791",
+        "end_year": "",
+        "event_date_range": "Jul 1, 1791"
+      },
+      {
+        "id": "57",
+        "era": "Early Republic and Loyalism",
+        "name": "Haitian Revolution",
+        "start_date": "1791-08-21",
+        "end_date": "1800-01-01",
+        "notes": "Following the outbreak of the French Revolution and partially inspired by its ideals of freedom and equality, the Haitian Revolution began as a slave revolt and ended with the establishment of the first independent Black republic.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1791",
+        "end_year": "1800",
+        "event_date_range": "Aug 21, 1791 - Jan 1, 1800"
+      }
+    ],
+    "1792": [
+      {
+        "id": "58",
+        "era": "Early Republic and Loyalism",
+        "name": "Kentucky admitted as a state",
+        "start_date": "1792-06-01",
+        "end_date": null,
+        "notes": "Kentucky splits from Virginia and becomes its own state",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1792",
+        "end_year": "",
+        "event_date_range": "Jun 1, 1792"
+      },
+      {
+        "id": "59",
+        "era": "Early Republic and Loyalism",
+        "name": "Execution of Louis XVI",
+        "start_date": "1792-09-12",
+        "end_date": null,
+        "notes": "Louis XVI is beheadded in Paris by revolutionaries, ending the Bourbon dynasty.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1792",
+        "end_year": "",
+        "event_date_range": "Sep 12, 1792"
+      }
+    ],
+    "1794": [
+      {
+        "id": "68",
+        "era": "Early Republic and Loyalism",
+        "name": "Whiskey Rebellion",
+        "start_date": "1794-01-01",
+        "end_date": null,
+        "notes": "Resistence to the 1791 Whisky Act culminates in an armed insurrection in western Pennsylvania. As with the earlier Shays' Rebellion, the Whiskey Rebellion represented a major challenge to the new United States government and the balance of power between the federal and state governments.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1794",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1794"
+      },
+      {
+        "id": "60",
+        "era": "Early Republic and Loyalism",
+        "name": "Jay Treaty",
+        "start_date": "1794-11-19",
+        "end_date": null,
+        "notes": "Meant to resolve lingering issues left after the 1783 Treaty of Paris, the Jay Treaty called for the withdrawl of British troops from the Nothwest Territory, a determination of the precise border between the American States and the remaining British Colonies, and sent contined issues regarding wartime debts to arbitration. Americans were also granted some trade rights with British possessions.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1794",
+        "end_year": "",
+        "event_date_range": "Nov 19, 1794"
+      }
+    ],
+    "1795": [
+      {
+        "id": "69",
+        "era": "Early Republic and Loyalism",
+        "name": "Second Maroon War",
+        "start_date": "1795-01-01",
+        "end_date": "1796-01-01",
+        "notes": "Jamaican Maroons, descendants of escaped slaves living in the mountainous interior of the colony, attack the British after a series of public humiliations. The eight-month war ended in Maroon defeat and a deportation of the Maroon population to Nova Scotia.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1795",
+        "end_year": "1796",
+        "event_date_range": "Jan 1, 1795 - Jan 1, 1796"
+      },
+      {
+        "id": "70",
+        "era": "Early Republic and Loyalism",
+        "name": "Second Carib War",
+        "start_date": "1795-01-01",
+        "end_date": "1797-01-01",
+        "notes": "A coalition of Caribs, enslaved people, and the French attack British forces in St Vincent. The Caribs and their allies were defeated and the Caribs were deported to Roatán.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1795",
+        "end_year": "1797",
+        "event_date_range": "Jan 1, 1795 - Jan 1, 1797"
+      },
+      {
+        "id": "61",
+        "era": "Early Republic and Loyalism",
+        "name": "Fédon's Rebellion",
+        "start_date": "1795-03-02",
+        "end_date": "1796-06-19",
+        "notes": "Inspired by the Haitian Revolution, a group of mixed-race free people under the leadership of Julien Fédon and supported by some enslaved people rose up against the British in Grenada. The revolt was brutally repressed and ultimately failed.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1795",
+        "end_year": "1796",
+        "event_date_range": "Mar 2, 1795 - Jun 19, 1796"
+      },
+      {
+        "id": "62",
+        "era": "Early Republic and Loyalism",
+        "name": "Pointe Coupée Slave Conspiracy, 1795",
+        "start_date": "1795-04-01",
+        "end_date": null,
+        "notes": "Inspired by the Haitian Revolution, enslaved people in Pointe Coupée Parish, Louisiana once again attempt an uprising against their enslavers. Betrayed to Spanish officials, the ensuing trial saw 57 enslaved people and three whites convicted. 23 enslaved people were executed and had their heads displayed on pikes along the Mississippi River in a blunt display of official power and terror.",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1795",
+        "end_year": "",
+        "event_date_range": "Apr 1, 1795"
+      }
+    ],
+    "1796": [
+      {
+        "id": "63",
+        "era": "Early Republic and Loyalism",
+        "name": "Tennessee admitted as a state",
+        "start_date": "1796-06-01",
+        "end_date": null,
+        "notes": "Tennessee, previously the federal Southwest Territory after being split off from North Carolina, is admitted as a state",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1796",
+        "end_year": "",
+        "event_date_range": "Jun 1, 1796",
+        "solr_ids_array": [
+          "commonwealth:q524n8339"
+        ]
+      }
+    ],
+    "1797": [
+      {
+        "id": "71",
+        "era": "Early Republic and Loyalism",
+        "name": "North American Border Commission",
+        "start_date": "1797-01-01",
+        "end_date": null,
+        "notes": "In the wake of the Jay Treaty, commissioners representing the United States and the remianing British colonies descend Passamquoddy Bay between what is now the state of Maine and the Canadian province of New Brunswick to determine the exact location of the international border. At issue was which of the rivers emptying to the bay was the historic St. Croix river. Relying on Indigenous testimony, seventeenth-century French documentation, and amateur archaeological digs, the issue is ultimately decided in favor of the British position, creating the modern US-Canada border. This commission, the first to determine issues of territorial extent using binding arbitration, set a diplomatic precendent still influential today.",
+        "is_geographic_event": "1",
+        "hide": null,
+        "start_year": "1797",
+        "end_year": "",
+        "event_date_range": "Jan 1, 1797"
+      }
+    ],
+    "1798": [
+      {
+        "id": "64",
+        "era": "Early Republic and Loyalism",
+        "name": "Quasi-War",
+        "start_date": "1798-07-07",
+        "end_date": "1800-09-30",
+        "notes": "Near war between the United States and the first French Republic",
+        "is_geographic_event": null,
+        "hide": null,
+        "start_year": "1798",
+        "end_year": "1800",
+        "event_date_range": "Jul 7, 1798 - Sep 30, 1800"
+      }
+    ]
+  }
+}

--- a/src/components/Layout/Homepage/Timeline.vue
+++ b/src/components/Layout/Homepage/Timeline.vue
@@ -6,7 +6,7 @@
 			Explore by Timelines
 		</span>
 	  </h2>
-      <ul class="flex flex-wrap gap-1">
+      <ul class="flex flex-wrap gap-1" v-if="data">
         <li v-for="(era, eraYear) in data.timeline_eras" :key="eraYear">
           <a @click="scrollTo(eraYear)" :class="['pill', 'cursor-pointer', { 'pill-active': showEra == eraYear }]">{{ era.era }}</a>
         </li>
@@ -108,17 +108,19 @@ const $drawerIdentifiers = useStore(drawerIdentifiers);
 <script>
 export default {
 	props: {
-		data: Object
+		jsonSrc: String
 	},
 	data() {
 		return {
 			ready: false,
 			isMobile: false,
-			showEra: Object.keys(this.data.timeline_eras)[0],
 		};
 	},
-	beforeMount() {
-		this.resize();
+	async beforeMount() {
+    const response = await fetch(this.jsonSrc);
+    this.data = await response.json();
+    this.showEra = Object.keys(this.data.timeline_eras)[0],
+    this.resize();
     this.ready = true; // prevent painting before data is available
 	},
 	mounted() {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,6 @@ import SearchByMap from "@components/SearchByMap/SearchByMap.astro"
 
 const title = 'Home';
 const description = 'American Revolutionary Geographies Online (ARGO) is a portal containing thousands of maps from dozens of institutions that bring to life the history and geography of the American Revolutionary War era.'
-const timelineData = await getEntry("timeline", "timeline");
 
 const storyEntries = await getCollection('stories');
 const storyIdentifiers = storyEntries.map((entry) => (
@@ -46,7 +45,7 @@ mapEntriesSanitized.forEach((entry) => (
   <SearchHero slot="hero" />
   <CollectionGrid className="mb-12" title="Explore by Story" contentType="stories" columns={3} identifiers={storyIdentifiers}, maxCards="3" morePage="/stories/" />
   <CollectionGrid className="mb-12" title="Explore by Theme" contentType="facets" columns={4} identifiers={facetIdentifiers}, maxCards="4" morePage="/facets/" />
-  <Timeline data={timelineData.data} client:load />
+  <Timeline jsonSrc="/content/timeline/timeline.json" client:load />
   <SearchByMap />
   <CollectionGrid className="mb-12" title="Explore by Empires & Nations" contentType="facetCategories" columns={5} identifiers={['empires-and-nations']}, maxCards="5"  morePage="/facets/empires-and-nations/" />
   <CollectionGrid className="mb-12" title="Explore by Features" contentType="facetCategories" columns={5} identifiers={['features']}, maxCards="5"  morePage="/facets/features/" />


### PR DESCRIPTION
In order to load timeline data dynamically (fetching by filename passed as a prop) I relocated the main timeline.json file to the `/public/content` directory.  I couldn't immediately figure out how to dyamically import data from the `/content` directory before vue is initialized and props are loaded.  Let me know if you foresee any issues related to that!