### PR TITLE
improvements to mobile view

### DIFF
--- a/src/components/Maps/InlineMapViewer.astro
+++ b/src/components/Maps/InlineMapViewer.astro
@@ -20,8 +20,8 @@ const collectionURI = `/maps/${identifier.replace("__", ":")}`;
 
 <div class="px-4">
   <div class="bg-gray-100 w-full rounded">
-    <div class="flex p-4">
-      <div class="text-bold flex-grow font-heading mr-4">
+    <div class="flex flex-col md:flex-row p-2 md:p-4 gap-2">
+      <div class="text-bold flex-grow font-heading">
         {recordData.data.dcMetadata.title_info_primary_tsi}
       </div>
       <div>

--- a/src/pages/stories/[slug].astro
+++ b/src/pages/stories/[slug].astro
@@ -20,7 +20,7 @@ const { Content } = await entry.render();
 ---
 <BaseLayout title={title} image={entry.data.banner_image} description={entry.data.short_description}>
   <div>
-    <article class="prose max-w-none">
+    <article class="prose max-w-none break-words">
       <div class="pb-2">
         <span class="inline-flex items-center rounded-full bg-gray-50 px-4 py-2 text-lg font-medium text-bismark-600 ring-2 ring-inset ring-clementine-600/20">{ story_type }</span>
 


### PR DESCRIPTION
@hkemp2128 @almontg This makes two very slight adjustments to UI to improve legibility at mobile size. First, it adds the `break-words` class to articles, which will force long URLs that are longer than the browser width to break across lines (in Richard's article, for instance, long URLs in the footnotes were forcing horizontal scrolling). It also does some light cleanup of the `InlineMapViewer` component that slightly improves its layout for smaller screens.