### PR TITLE
implement download prevention

### DIFF
--- a/src/pages/maps/[identifier].astro
+++ b/src/pages/maps/[identifier].astro
@@ -91,7 +91,7 @@ const metaImage = "https://iiif.digitalcommonwealth.org/iiif/2/" + data.dcMetada
             </ul>
           </div>
 
-          { data.dcMetadata.exemplary_image_ssi && data.dcMetadata.identifier_iiif_manifest_ss.includes('ark.digitalcommonwealth') &&
+          { data.dcMetadata.exemplary_image_ssi && data.dcMetadata.identifier_iiif_manifest_ss.includes('ark.digitalcommonwealth') && !data.dcMetadata.license_ss.includes('Contact host institution') &&
             <div>
               <h2 class="text-xl mb-1">Downloads</h2>
               <div class="flex flex-wrap gap-x-1 gap-y-2">


### PR DESCRIPTION
@almontg @hkemp2128 This is a quick fix to the issue of IIIF image downloads being exposed to the user even when the rights statement is "Contact host institution to download image." May want to evaluate for long-term robustness but right now it simply disables the Downloads section if the phrase "Contact host institution" is found in `license_ss`