### PR TITLE
alphabetize partner collection grid

### DIFF
--- a/src/pages/partner-collections/index.astro
+++ b/src/pages/partner-collections/index.astro
@@ -6,9 +6,9 @@ import CollectionGrid from "@components/CollectionGrid.astro";
 
 const title = 'Partner Collections';
 const entries = await getCollection('partner-collections');
-const identifiers = entries.map((entry) => (
-  entry.id
-));
+const identifiers = entries
+  .sort((a, b) => a.data.title_info_primary_ssi.localeCompare(b.data.title_info_primary_ssi))
+  .map((entry) => entry.id);
 
 ---
 <BaseLayout title={title}>


### PR DESCRIPTION
Previously, partner collections were ordered arbitrarily; this change fixes the page to put their cards in alphabetical order