### PR TITLE
Disable banner announcement

### DIFF
--- a/src/site_config.json
+++ b/src/site_config.json
@@ -1,6 +1,6 @@
 {
     "announcementBanner": {
-        "enabled": true,
+        "enabled": false,
         "message": "This site is experiencing technical difficulties and some features and content are currently unavailable. We apologize for the inconvenience and are working to resolve the issue."
     }
 }


### PR DESCRIPTION
DC is working again; this feature removes the banner (though retains the ability to turn it on via changes to `site_config.json`)